### PR TITLE
Resend expired account activation tokens

### DIFF
--- a/api/src/routes/auth/data.ts
+++ b/api/src/routes/auth/data.ts
@@ -136,13 +136,17 @@ export async function getHeartbeatInfo(database: D1Database, id: string) {
 	return userInfo;
 }
 
-export async function checkExistingEmail(database: D1Database, email: string) {
-	const existingEmail = await database
-		.prepare(`SELECT email FROM ${DBTables.ACCESS} WHERE email = ? LIMIT 1`)
+export async function getExistingAccount(database: D1Database, email: string) {
+	return database
+		.prepare(`SELECT email, id, activatedAt FROM ${DBTables.ACCESS} WHERE email = ? LIMIT 1`)
 		.bind(email)
-		.first<{ email: string }>();
+		.first<{ email: string, id: string, activatedAt: string | null }>();
+}
 
-	return existingEmail !== null;
+export async function checkExistingEmail(database: D1Database, email: string) {
+	const existingAccount = await getExistingAccount(database, email);
+
+	return existingAccount !== null;
 }
 
 export async function checkActiveEmail(database: D1Database, email: string) {

--- a/api/src/routes/auth/index.test.ts
+++ b/api/src/routes/auth/index.test.ts
@@ -38,10 +38,23 @@ describe('Authentication routes', () => {
 
 			const tokens = await env.ActivationTokens.list();
 			expect(Array.isArray(tokens?.keys)).toBe(true);
-			expect(tokens.keys.length).toBe(1);
+			// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+			expect(tokens.keys.length).toBe(2);
 
-			const [firstActivationTokenKey] = tokens.keys;
+			const firstActivationTokenKey = tokens.keys.find(({ name }) => !name.startsWith('activation-resend:'));
 			assert(firstActivationTokenKey, 'First ActivationToken should exist.');
+			const activationResendKey = tokens.keys.find(({ name }) => name.startsWith('activation-resend:'));
+			assert(activationResendKey, 'Activation resend cooldown should exist.');
+			assert(firstActivationTokenKey.expiration, 'Activation token expiration should exist.');
+			assert(activationResendKey.expiration, 'Activation resend cooldown expiration should exist.');
+			expect(firstActivationTokenKey.expiration).toBe(activationResendKey.expiration);
+			// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+			const expectedTtlSeconds = 60 * 15;
+			// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+			const actualTtlSeconds = firstActivationTokenKey.expiration - Math.floor(Date.now() / 1000);
+			// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+			expect(actualTtlSeconds).toBeGreaterThanOrEqual(expectedTtlSeconds - 5);
+			expect(actualTtlSeconds).toBeLessThanOrEqual(expectedTtlSeconds);
 
 			const stored = await env.ActivationTokens.get(firstActivationTokenKey.name, 'json');
 			expect(stored).toEqual(expect.objectContaining({ email: newUserPayload.email }));
@@ -74,7 +87,73 @@ describe('Authentication routes', () => {
 			expect(profile?.avatar).toBe(newUserPayload.avatar);
 		});
 
-		it.todo('skips creation when the email already exists (idempotent sign-up path)');
+		it('does not resend while an unactivated account is on cooldown', async () => {
+			const payload = {
+				name: 'Cooldown User',
+				email: 'cooldown@example.com',
+				password: 'jfiewofjieowfjo2348219++++'
+			};
+
+			await app.request('/api/auth/sign-up', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(payload)
+			}, env);
+			const tokensBeforeRetry = await env.ActivationTokens.list();
+
+			const response = await app.request('/api/auth/sign-up', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(payload)
+			}, env);
+
+			expect(response.status).toBe(StatusCodes.OKAY);
+			expect((await env.ActivationTokens.list()).keys).toHaveLength(tokensBeforeRetry.keys.length);
+		});
+
+		it('creates a fresh activation token after the resend cooldown', async () => {
+			const payload = {
+				name: 'Resend User',
+				email: 'resend@example.com',
+				password: 'jfiewofjieowfjo2348219++++'
+			};
+
+			await app.request('/api/auth/sign-up', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(payload)
+			}, env);
+			const firstKeys = await env.ActivationTokens.list();
+			const cooldownKey = firstKeys.keys.find(({ name }) => name.startsWith('activation-resend:'));
+			assert(cooldownKey, 'Activation resend cooldown should exist.');
+			await env.ActivationTokens.delete(cooldownKey.name);
+
+			const response = await app.request('/api/auth/sign-up', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(payload)
+			}, env);
+
+			expect(response.status).toBe(StatusCodes.OKAY);
+			const activationKeys = (await env.ActivationTokens.list()).keys.filter(({ name }) => !name.startsWith('activation-resend:'));
+			// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+			expect(activationKeys).toHaveLength(2);
+		});
+
+		it('does not send an activation token for an existing active account', async () => {
+			const response = await app.request('/api/auth/sign-up', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					name: 'King Arthur',
+					email: 'king.arthur@camelot.uk',
+					password: 'H0lyGr@il42!L0rd'
+				})
+			}, env);
+
+			expect(response.status).toBe(StatusCodes.OKAY);
+			expect((await env.ActivationTokens.list()).keys).toHaveLength(0);
+		});
 
 		it('rejects sign-up when email is invalid', async () => {
 			const invalidEmailPayload = {

--- a/api/src/routes/auth/index.ts
+++ b/api/src/routes/auth/index.ts
@@ -10,12 +10,39 @@ import { hashPassword, validatePassword } from '../../utils/password-hashing.ts'
 import { passwordStrengthCheck } from '../../utils/passwordStrengthCheck.ts';
 import { StatusCodes, type StatusResponse, statusResponseFormatter, StatusResponseSchema } from '../../utils/responses.ts';
 import { insertProfile } from '../profile/data.ts';
-import { activateProfile, checkActiveEmail, checkExistingEmail, getHeartbeatInfo, getLoginInfo, resetPassword, updateProfileStatus } from './data.ts';
+import { activateProfile, checkActiveEmail, checkExistingEmail, getExistingAccount, getHeartbeatInfo, getLoginInfo, resetPassword, updateProfileStatus } from './data.ts';
 import { type HeartbeatResponse, HeartbeatResponseSchema } from './responses.ts';
 import { ActivateSchema, ForgotPasswordSchema, ResetPasswordSchema, ResetPasswordValidTokenSchema, SignInSchema, SignUpSchema } from './validation.ts';
 export const authRoutes = new OpenAPIHono<EnvironmentBindings>({
 	defaultHook: statusResponseFormatter
 });
+
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+const ACTIVATION_WINDOW_SECONDS = 60 * 15;
+const ACTIVATION_RESEND_KEY_PREFIX = 'activation-resend:';
+
+async function getActivationResendKey(email: string) {
+	const emailBytes = new TextEncoder().encode(email.toLowerCase());
+	const digest = await crypto.subtle.digest('SHA-256', emailBytes);
+	// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+	const emailHash = [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+
+	return `${ACTIVATION_RESEND_KEY_PREFIX}${emailHash}`;
+}
+
+async function sendActivationEmail(context: Parameters<typeof sendAccountConfirmationEmail>[0], { email, id }: { email: string, id: string }) {
+	const token = crypto.randomUUID();
+	const resendKey = await getActivationResendKey(email);
+
+	await context.env.ActivationTokens.put(resendKey, '1', { expirationTtl: ACTIVATION_WINDOW_SECONDS });
+	await context.env.ActivationTokens.put(token, JSON.stringify({ email, id }), { expirationTtl: ACTIVATION_WINDOW_SECONDS });
+	await sendAccountConfirmationEmail(context, {
+		apiKey: context.env.RESEND_API_KEY,
+		senderEmail: context.env.SENDER_EMAIL,
+		token,
+		email
+	});
+}
 
 authRoutes.openapi(
 	createRoute({
@@ -53,9 +80,15 @@ authRoutes.openapi(
 
 		const response = { message: 'Created a new profile and sent an email for confirmation' };
 
-		const emailExists = await checkExistingEmail(context.env.Database, email);
-		if (emailExists) {
-			// INFO: Hide non existing emails to reduce attack surface from guessing registered emails.
+		const existingAccount = await getExistingAccount(context.env.Database, email);
+		if (existingAccount) {
+			const resendKey = await getActivationResendKey(email);
+			const resendOnCooldown = await context.env.ActivationTokens.get(resendKey);
+			if (!existingAccount.activatedAt && !resendOnCooldown) {
+				await sendActivationEmail(context, existingAccount);
+			}
+
+			// INFO: Keep the response generic to prevent account enumeration.
 			return context.json(response satisfies StatusResponse, StatusCodes.OKAY);
 		}
 
@@ -72,21 +105,7 @@ authRoutes.openapi(
 		const { id } = await insertProfile(context.env.Database, { avatar: resolvedAvatar, email, password: hashedPasswordWithSalt, name });
 		await updateProfileStatus(context.env.Database, id);
 
-		// eslint-disable-next-line @typescript-eslint/no-magic-numbers
-		const TEN_MINUTES_IN_SECONDS = 60 * 10;
-		const token = crypto.randomUUID();
-		await context.env.ActivationTokens.put(
-			token,
-			JSON.stringify({ email, id }),
-			{ expirationTtl: TEN_MINUTES_IN_SECONDS }
-		);
-
-		await sendAccountConfirmationEmail(context, {
-			apiKey: context.env.RESEND_API_KEY,
-			senderEmail: context.env.SENDER_EMAIL,
-			token,
-			email
-		});
+		await sendActivationEmail(context, { email, id });
 
 		return context.json(response satisfies StatusResponse, StatusCodes.OKAY);
 	}


### PR DESCRIPTION
## Summary
- resend activation emails when an unactivated user signs up again
- use one 15-minute window for activation tokens and resend cooldowns
- store cooldowns in KV using hashed email keys
- preserve the generic signup response

## Testing
- npm run typecheck
- npm run test:unit
- npm run test:integration
- npm run build