### PR TITLE
Created the open_role and open_role_members in 0008_create-open-role.sql

### DIFF
--- a/.vite-dev.log
+++ b/.vite-dev.log
@@ -1,0 +1,44 @@
+
+> vms@0.0.1 dev
+> vite dev
+
+✓ Added main entry: O:\codes\communityhub\src\index.html
+✓ Added page: account-ready
+✓ Added page: button-usage
+✓ Added page: check-steps
+✓ Added page: check-your-email
+✓ Added page: complete-profile
+✓ Added page: confirm-account
+✓ Added page: date-usage
+✓ Added page: dev-links
+✓ Added page: forgot-password
+✓ Added page: home
+✓ Added page: notification-box-usage
+✓ Added page: notifications
+✓ Added page: print-documents
+✓ Added page: profile
+✓ Added page: profiles
+✓ Added page: protected-page-admins
+✓ Added page: protected-page-all
+✓ Added page: protected-page-organizers
+✓ Added page: protected-profile
+✓ Added page: reset-password
+✓ Added page: reset-password-success
+✓ Added page: review-conduct-code
+✓ Added page: sign-in
+✓ Added page: sign-up
+✓ Added page: team
+✓ Added page: teams
+✓ Added page: text-input-usage
+✓ Added page: usage-helper-message
+✓ Added page: volunteer
+Using vars defined in .dev.vars
+
+  VITE v7.0.5  ready in 1539 ms
+
+  ➜  Local:   http://localhost:3000/
+  ➜  Network: http://192.168.26.144:3000/
+  ➜  Debug:   http://localhost:3000/__debug
+  ➜  press h + enter to show help
+6:26:35 pm [vite] Pre-transform error: Failed to load url /sign-up.tsx (resolved id: /sign-up.tsx). Does the file exist?
+6:26:48 pm [vite] Pre-transform error: Failed to load url /sign-in.tsx (resolved id: /sign-in.tsx). Does the file exist?

--- a/db/migrations/0008_create-open-role.sql
+++ b/db/migrations/0008_create-open-role.sql
@@ -8,28 +8,28 @@ CREATE TABLE IF NOT EXISTS open_role(
 	-- The UUID, stored as text
 	id TEXT NOT NULL UNIQUE COLLATE BINARY,
 	-- The name of the open role
-	open_role_name TEXT NOT NULL,
+	openRoleName TEXT NOT NULL,
 	-- A text blurb the person can provide about themselves
-	open_role_description TEXT,
+	openRoleDescription TEXT,
 	-- A flag indicating if the user is based on the Grater Toronto Area (GTA)
 	-- This and the following flags are a proxy for information if people can attend online and in person events.
 	-- It is enough to give us information if the person is around Toronto without needing to ask the actual location.
 	isBasedOnGTA INTEGER NOT NULL DEFAULT 1 CHECK(isBasedOnGTA IN (0, 1)),
 	-- The experience level of the open role (senior, mid, entry)
-	experience_level TEXT NOT NULL CHECK(experience_level IN ('senior', 'mid', 'entry')),
+	experienceLevel TEXT NOT NULL CHECK(experienceLevel IN ('senior', 'mid', 'entry')),
 	-- The tech stacks required for the open role
-	tech_stacks TEXT NOT NULL,
+	techStacks TEXT NOT NULL,
 	-- The position of the open role (1,2,5...)
-	position_required INTEGER NOT NULL,
+	positionRequired INTEGER NOT NULL,
 	-- The team id of the open role (FK of Team(id))
-	team_id TEXT NOT NULL,
+	teamId TEXT NOT NULL,
 	-- The date this open role was added to the database, saved as an ISO timestamp
 	insertedAt DATETIME NOT NULL,
 	-- The date this open role was deleted from the database, saved as an ISO timestamp
 	deletedAt DATETIME DEFAULT NULL,
 
 	PRIMARY KEY (id),
-	FOREIGN KEY (team_id) REFERENCES team(id)
+	FOREIGN KEY (teamId) REFERENCES team(id)
 );
 
 Drop TABLE IF EXISTS open_role_members;
@@ -37,17 +37,17 @@ CREATE TABLE IF NOT EXISTS open_role_members(
 -- The UUID, stored as text
 	id TEXT NOT NULL UNIQUE COLLATE BINARY,
 	--Foreign key to the open role member (FK of open-role(id))
-	open_role_id TEXT NOT NULL,
+	openRoleId TEXT NOT NULL,
 	-- The profile id of the open role member (FK of profile(id))
-	profile_id TEXT NOT NULL,
+	profileId TEXT NOT NULL,
 	-- The open role name of the open role member (FK of open_role(open_role_name))
-	open_role_name TEXT NOT NULL,
+	openRoleName TEXT NOT NULL,
 	-- The date this open role member was added to the database, saved as an ISO timestamp
 	insertedAt DATETIME NOT NULL,
 	-- The date this open role member was deleted from the database, saved as an ISO timestamp
 	deletedAt DATETIME DEFAULT NULL,
 	PRIMARY KEY (id),
-	FOREIGN KEY (open_role_id) REFERENCES open_role(id),
-	FOREIGN KEY (profile_id) REFERENCES profile(id),
-	FOREIGN KEY (open_role_name) REFERENCES open_role(open_role_name)
+	FOREIGN KEY (openRoleId) REFERENCES open_role(id),
+	FOREIGN KEY (profileId) REFERENCES profile(id),
+	FOREIGN KEY (openRoleName) REFERENCES open_role(openRoleName)
 );

--- a/db/migrations/0008_create-open-role.sql
+++ b/db/migrations/0008_create-open-role.sql
@@ -1,10 +1,10 @@
 -- Migration number: 0002 	 2025-01-30T00:58:21.685Z
 
-DROP TABLE IF EXISTS open-role;
+DROP TABLE IF EXISTS open_role;
 
 -- A person's profile inside the database
 -- It should contain no sensitive information
-CREATE TABLE IF NOT EXISTS open-role(
+CREATE TABLE IF NOT EXISTS open_role(
 	-- The UUID, stored as text
 	id TEXT NOT NULL UNIQUE COLLATE BINARY,
 	-- The name of the open role
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS open_role_members(
 	-- The date this open role member was deleted from the database, saved as an ISO timestamp
 	deletedAt DATETIME DEFAULT NULL,
 	PRIMARY KEY (id),
-	FOREIGN KEY (open_role_id) REFERENCES open-role(id),
+	FOREIGN KEY (open_role_id) REFERENCES open_role(id),
 	FOREIGN KEY (profile_id) REFERENCES profile(id),
-	FOREIGN KEY (open_role_name) REFERENCES open-role(open_role_name)
+	FOREIGN KEY (open_role_name) REFERENCES open_role(open_role_name)
 );

--- a/db/migrations/0008_create-open-role.sql
+++ b/db/migrations/0008_create-open-role.sql
@@ -1,0 +1,53 @@
+-- Migration number: 0002 	 2025-01-30T00:58:21.685Z
+
+DROP TABLE IF EXISTS open-role;
+
+-- A person's profile inside the database
+-- It should contain no sensitive information
+CREATE TABLE IF NOT EXISTS open-role(
+	-- The UUID, stored as text
+	id TEXT NOT NULL UNIQUE COLLATE BINARY,
+	-- The name of the open role
+	open_role_name TEXT NOT NULL,
+	-- A text blurb the person can provide about themselves
+	open_role_description TEXT,
+	-- A flag indicating if the user is based on the Grater Toronto Area (GTA)
+	-- This and the following flags are a proxy for information if people can attend online and in person events.
+	-- It is enough to give us information if the person is around Toronto without needing to ask the actual location.
+	isBasedOnGTA INTEGER NOT NULL DEFAULT 1 CHECK(isBasedOnGTA IN (0, 1)),
+	-- The experience level of the open role (senior, mid, entry)
+	experience_level TEXT NOT NULL CHECK(experience_level IN ('senior', 'mid', 'entry')),
+	-- The tech stacks required for the open role
+	tech_stacks TEXT NOT NULL,
+	-- The position of the open role (1,2,5...)
+	position_required INTEGER NOT NULL,
+	-- The team id of the open role (FK of Team(id))
+	team_id TEXT NOT NULL,
+	-- The date this open role was added to the database, saved as an ISO timestamp
+	insertedAt DATETIME NOT NULL,
+	-- The date this open role was deleted from the database, saved as an ISO timestamp
+	deletedAt DATETIME DEFAULT NULL,
+
+	PRIMARY KEY (id),
+	FOREIGN KEY (team_id) REFERENCES team(id)
+);
+
+Drop TABLE IF EXISTS open_role_members;
+CREATE TABLE IF NOT EXISTS open_role_members(
+-- The UUID, stored as text
+	id TEXT NOT NULL UNIQUE COLLATE BINARY,
+	--Foreign key to the open role member (FK of open-role(id))
+	open_role_id TEXT NOT NULL,
+	-- The profile id of the open role member (FK of profile(id))
+	profile_id TEXT NOT NULL,
+	-- The open role name of the open role member (FK of open_role(open_role_name))
+	open_role_name TEXT NOT NULL,
+	-- The date this open role member was added to the database, saved as an ISO timestamp
+	insertedAt DATETIME NOT NULL,
+	-- The date this open role member was deleted from the database, saved as an ISO timestamp
+	deletedAt DATETIME DEFAULT NULL,
+	PRIMARY KEY (id),
+	FOREIGN KEY (open_role_id) REFERENCES open-role(id),
+	FOREIGN KEY (profile_id) REFERENCES profile(id),
+	FOREIGN KEY (open_role_name) REFERENCES open-role(open_role_name)
+);


### PR DESCRIPTION
## Summary

This PR introduces the database schema required to support the **Open Roles** feature in the TorontoJS Community application.

### Changes

#### Added `open_role` table

The `open_role` table stores public opportunities posted by a team.

Fields:
- `id`
- `open_role_name`
- `open_role_description`
- `isBasedOnGTA`
- `experience_level`
- `tech_stacks`
- `position_required`
- `team_id` (FK → `team.id`)
- `insertedAt`
- `deletedAt`

#### Added `open_role_members` table

The `open_role_members` table stores members who have applied for an open role.

Fields:
- `id`
- `open_role_id` (FK → `open_role.id`)
- `profile_id` (FK → `profile.id`)
- `open_role_name` (FK → `open_role.open_role_name`)
- `insertedAt`
- `deletedAt`

### Database Relationships

```
team
  │
  │ 1
  ▼
open_role
  │
  │ 1
  ▼
open_role_members
  ▲
  │
profile
```
This schema establishes the foundation for supporting public community opportunities and member applications.

## Tests

---I have not done any tests

---

## Additional Information
---No additional info

