### PR TITLE
fix(profile): allow editing general info without a gravatar avatar

### DIFF
--- a/src/components/ProtectedProfile/ProtectedProfile.tsx
+++ b/src/components/ProtectedProfile/ProtectedProfile.tsx
@@ -207,10 +207,11 @@ export const ProtectedProfile = (): React.JSX.Element => {
 	const handleGeneralInfoSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<boolean> => {
 		event.preventDefault();
 		const formData = new FormData(event.currentTarget);
+		const rawAvatar = (formData.get('avatar') as string)?.trim();
 
 		const updatedData = {
 			name: (formData.get('name') as string)?.trim(),
-			avatar: (formData.get('avatar') as string)?.trim() || null,
+			avatar: rawAvatar && !rawAvatar.startsWith('/') ? rawAvatar : null,
 			pronouns: (formData.get('pronouns') as string)?.trim() || undefined,
 			canJoinLocalEvents: formData.get('canJoinLocalEvents') === 'on',
 			isBasedOnGTA: formData.get('isBasedOnGTA') === 'on'


### PR DESCRIPTION
## Summary

Fixes #348 — a bug where users without a Gravatar avatar could not save any general profile info edits (name, pronouns, GTA/local-event flags).

The `GeneralInfoFormModal` submits the avatar via a hidden input. For users without a Gravatar, the frontend substitutes the local default avatar (`/default-avatar.png`). That path was sent to `PATCH /api/profiles/{id}`, where `UpdateProfileSchema` / `AvatarSchema` requires an absolute Gravatar URL, so the request was rejected with 422 and the save silently failed.

The form now sends `null` for the avatar when it is empty or a local path, which the schema already accepts (`avatar: AvatarSchema.nullable().optional()`) and the DB column already supports.

## Tests

- Manually verify: editing general info as a user without a Gravatar avatar now succeeds