### PR TITLE
feat: add community email notifications

### DIFF
--- a/api/src/email/index.ts
+++ b/api/src/email/index.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono';
 import { type CreateEmailResponse, Resend } from 'resend';
+import { generateCommunityNotificationHtml } from './templates/community-notification.ts';
 
 interface EmailSendingParams {
 	apiKey: string;
@@ -10,7 +11,7 @@ interface EmailSendingParams {
 	text?: string;
 }
 
-async function sendEmail(context: Context<EnvironmentBindings>, { apiKey, from, to, subject, text, html }: EmailSendingParams) {
+export async function sendEmail(context: Context<EnvironmentBindings>, { apiKey, from, to, subject, text, html }: EmailSendingParams) {
 	if (context.env.ARE_EMAILS_LOCAL_ONLY === 'true') {
 		/* eslint-disable no-console */
 		console.log(`[📨] You got mail!`);
@@ -27,6 +28,46 @@ async function sendEmail(context: Context<EnvironmentBindings>, { apiKey, from, 
 	const emailResponse = await resend.emails.send({ from, to, subject, text, html });
 
 	return emailResponse;
+}
+
+const HTML_ENTITIES: Record<string, string> = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#039;'
+};
+
+function escapeHtml(value: string) {
+	return value.replace(/[&<>"']/gu, (character) => HTML_ENTITIES[character] ?? character);
+}
+
+interface CommunityNotificationEmailParams {
+	email: string;
+	message: string;
+	apiKey: string;
+	senderEmail: string;
+	subject: string;
+}
+
+export async function sendCommunityNotificationEmail(context: Context<EnvironmentBindings>, {
+	email,
+	message,
+	apiKey,
+	senderEmail,
+	subject
+}: CommunityNotificationEmailParams) {
+	const escapedMessage = escapeHtml(message).replace(/\n/gu, '<br>');
+	const logoUrl = new URL('/torontojs-logo.png', context.env.FRONTEND_URL).toString();
+
+	return sendEmail(context, {
+		apiKey,
+		from: senderEmail,
+		to: email,
+		subject,
+		text: message,
+		html: generateCommunityNotificationHtml(logoUrl, escapeHtml(subject), escapedMessage)
+	});
 }
 
 interface AccountConfirmationEmailParams {

--- a/api/src/email/templates/community-notification.ts
+++ b/api/src/email/templates/community-notification.ts
@@ -1,0 +1,208 @@
+// `subject` and `messageHtml` must already be HTML-escaped by the caller before they reach this template.
+export function generateCommunityNotificationHtml(logoUrl: string, subject: string, messageHtml: string) {
+	return `
+    <!doctype html>
+    <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+    <head>
+      <title>
+      </title>
+      <!--[if !mso]><!-->
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <!--<![endif]-->
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <style type="text/css">
+        #outlook a {
+          padding: 0;
+        }
+
+        body {
+          margin: 0;
+          padding: 0;
+          -webkit-text-size-adjust: 100%;
+          -ms-text-size-adjust: 100%;
+        }
+
+        table,
+        td {
+          border-collapse: collapse;
+          mso-table-lspace: 0pt;
+          mso-table-rspace: 0pt;
+        }
+
+        img {
+          border: 0;
+          height: auto;
+          line-height: 100%;
+          outline: none;
+          text-decoration: none;
+          -ms-interpolation-mode: bicubic;
+        }
+
+        p {
+          display: block;
+          margin: 13px 0;
+        }
+      </style>
+      <!--[if mso]>
+        <noscript>
+        <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG/>
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+        </xml>
+        </noscript>
+        <![endif]-->
+      <!--[if lte mso 11]>
+        <style type="text/css">
+          .mj-outlook-group-fix { width:100% !important; }
+        </style>
+        <![endif]-->
+      <!--[if !mso]><!-->
+      <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400&display=swap" rel="stylesheet" type="text/css">
+      <style type="text/css">
+        @import url(https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400&display=swap);
+      </style>
+      <!--<![endif]-->
+      <style type="text/css">
+        @media only screen and (min-width:480px) {
+          .mj-column-per-100 {
+            width: 100% !important;
+            max-width: 100%;
+          }
+        }
+      </style>
+      <style media="screen and (min-width:480px)">
+        .moz-text-html .mj-column-per-100 {
+          width: 100% !important;
+          max-width: 100%;
+        }
+      </style>
+      <style type="text/css">
+        @media only screen and (max-width:480px) {
+          table.mj-full-width-mobile {
+            width: 100% !important;
+          }
+
+          td.mj-full-width-mobile {
+            width: auto !important;
+          }
+        }
+      </style>
+      <style type="text/css">
+      </style>
+    </head>
+
+    <body style="word-spacing:normal;background-color:#eeeeee;">
+      <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;"> ${subject} </div>
+      <div style="background-color:#eeeeee;">
+        <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:600px;">
+          <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+            <tbody>
+              <tr>
+                <td style="border-top:8px solid #ED342F;direction:ltr;font-size:0px;padding:0;text-align:center;">
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                      <tbody>
+                        <tr>
+                          <td align="center" style="font-size:0px;padding:40px;word-break:break-word;">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+                              <tbody>
+                                <tr>
+                                  <td style="width:128px;">
+                                    <img alt="TorontoJS logo" height="auto" src="${logoUrl}" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="128">
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:600px;">
+          <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+            <tbody>
+              <tr>
+                <td style="direction:ltr;font-size:0px;padding:0 24px;text-align:center;">
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:552px;" ><![endif]-->
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                      <tbody>
+                        <tr>
+                          <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                            <div style="font-family:'Source Sans 3', Helvetica, Arial, sans-serif;font-size:18px;font-weight:400;line-height:1.6;text-align:center;color:#555555;">
+                              <h1 style="padding: 0; margin: 0; font-weight: 400; font-size: 32px; letter-spacing: -0.5px;">${subject}</h1>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td style="font-size:0px;word-break:break-word;">
+                            <div style="height:40px;line-height:40px;">&#8202;</div>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                            <div style="font-family:'Source Sans 3', Helvetica, Arial, sans-serif;font-size:18px;font-weight:400;line-height:1.6;text-align:center;color:#555555;">
+                              <p style="padding: 0; margin: 0; font-weight: 400;">${messageHtml}</p>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td style="font-size:0px;word-break:break-word;">
+                            <div style="height:40px;line-height:40px;">&#8202;</div>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <div style="margin:0px auto;max-width:600px;">
+          <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+            <tbody>
+              <tr>
+                <td style="border-top:8px solid #ED342F;direction:ltr;font-size:0px;padding:20px 24px;text-align:center;">
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:552px;" ><![endif]-->
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                      <tbody>
+                        <tr>
+                          <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                            <div style="font-family:'Source Sans 3', Helvetica, Arial, sans-serif;font-size:14px;font-weight:400;line-height:1.6;text-align:center;color:#555555;">
+                              <p style="padding: 0; margin: 0; font-weight: 400;">TorontoJS Community Hub</p>
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    </body>
+
+    </html>
+  `;
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,6 +7,7 @@ import { secureHeaders } from 'hono/secure-headers';
 import packageJson from '../../package.json' with { type: 'json' };
 import { authRoutes } from './routes/auth/index.ts';
 import { documentRoutes } from './routes/documents/index.ts';
+import { emailCampaignRoutes } from './routes/email-campaign/index.ts';
 import { healthCheckRoutes } from './routes/health-check/index.ts';
 import { profileRoutes } from './routes/profile/index.ts';
 import { teamMemberRoutes } from './routes/team-members/index.ts';
@@ -92,6 +93,7 @@ apiRoutes.route('/', healthCheckRoutes);
 apiRoutes.route('/auth', authRoutes);
 apiRoutes.route('/profiles', profileRoutes);
 apiRoutes.route('/documents', documentRoutes);
+apiRoutes.route('/email-campaigns', emailCampaignRoutes);
 apiRoutes.route('/teams', teamRoutes);
 // All routes follow the format /teams/{id}/members
 apiRoutes.route('/teams', teamMemberRoutes);

--- a/api/src/routes/email-campaign/data.test.ts
+++ b/api/src/routes/email-campaign/data.test.ts
@@ -1,0 +1,103 @@
+import { applyD1Migrations, env } from 'cloudflare:test';
+import { assert, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import {
+	finishCampaign,
+	getAudienceOptions,
+	getCampaignByIdempotencyKey,
+	insertCampaign,
+	resolveAudience,
+	updateRecipientDelivery
+} from './data.ts';
+
+const DEFAULT_TEAM_ID = 'b3410598-ecbc-41be-9f68-925da74bc613';
+const ORGANIZER_ID = '3c5123c0-8548-4a02-a83c-32e9ce67eae8';
+const SECOND_TEAM_ID = '70ca1ff2-6ab6-4533-ae79-203f5b08742c';
+
+beforeAll(async () => {
+	await applyD1Migrations(env.Database, env.TEST_MIGRATIONS);
+});
+
+beforeEach(async () => {
+	await env.Database.exec(env.SEED_SQL);
+});
+
+describe('Email campaign data', () => {
+	test('lists only active audience profiles and active teams', async () => {
+		const options = await getAudienceOptions(env.Database);
+
+		expect(options.profiles.length).toBeGreaterThan(0);
+		expect(options.teams.length).toBeGreaterThan(0);
+		expect(options.profiles.some(({ email }) => email === 'mrs.bun@whizzo.choc')).toBe(false);
+		expect(options.profiles.some(({ email }) => email === 'knight.ni@forestsayni.com')).toBe(false);
+		expect(options.profiles.every(({ teamIds }) => Array.isArray(teamIds))).toBe(true);
+	});
+
+	test('deduplicates people who belong to more than one selected team', async () => {
+		const recipients = await resolveAudience(env.Database, {
+			mode: 'selected',
+			teamIds: [DEFAULT_TEAM_ID, SECOND_TEAM_ID],
+			profileIds: [],
+			accessLevels: [],
+			profileStatuses: []
+		});
+		const recipientIds = recipients.map(({ id }) => id);
+
+		expect(new Set(recipientIds).size).toBe(recipientIds.length);
+	});
+
+	test('narrows recipients using access, status, and location filters', async () => {
+		const recipients = await resolveAudience(env.Database, {
+			mode: 'all',
+			teamIds: [],
+			profileIds: [],
+			accessLevels: ['volunteer'],
+			profileStatuses: ['tos-accepted'],
+			isBasedOnGTA: true,
+			canJoinLocalEvents: true
+		});
+
+		expect(recipients.length).toBeGreaterThan(0);
+		expect(recipients.every((profile) =>
+			profile.accessLevel === 'volunteer' &&
+			profile.profileStatus === 'tos-accepted' &&
+			profile.isBasedOnGTA &&
+			profile.canJoinLocalEvents
+		)).toBe(true);
+	});
+
+	test('stores a campaign recipient snapshot and delivery result', async () => {
+		const audience = {
+			mode: 'selected' as const,
+			teamIds: [],
+			profileIds: [ORGANIZER_ID],
+			accessLevels: [],
+			profileStatuses: []
+		};
+		const recipients = await resolveAudience(env.Database, audience);
+		const idempotencyKey = crypto.randomUUID();
+		const { campaignId, recipients: campaignRecipients } = await insertCampaign(env.Database, ORGANIZER_ID, {
+			subject: 'Test campaign',
+			message: 'Test message',
+			audience,
+			idempotencyKey
+		}, recipients);
+
+		expect(campaignRecipients).toHaveLength(1);
+		const [campaignRecipient] = campaignRecipients;
+		assert(campaignRecipient, 'Campaign recipient should exist.');
+		await updateRecipientDelivery(env.Database, campaignRecipient.id, 'sent', 'provider-message-id');
+		await finishCampaign(env.Database, campaignId, 'sent', 1, 0);
+
+		const summary = await getCampaignByIdempotencyKey(env.Database, idempotencyKey);
+		const recipient = await env.Database.prepare('SELECT email, status, providerMessageId FROM email_campaign_recipient WHERE campaignId = ?')
+			.bind(campaignId)
+			.first<{ email: string, status: string, providerMessageId: string }>();
+
+		expect(summary).toMatchObject({ id: campaignId, recipientCount: 1, sentCount: 1, failedCount: 0, status: 'sent' });
+		expect(recipient).toEqual({
+			email: 'king.arthur@camelot.uk',
+			status: 'sent',
+			providerMessageId: 'provider-message-id'
+		});
+	});
+});

--- a/api/src/routes/email-campaign/data.ts
+++ b/api/src/routes/email-campaign/data.ts
@@ -1,0 +1,263 @@
+import { DBTables, generateBaseDBfields } from '../../utils/db.ts';
+import type {
+	AudienceProfile,
+	CreateEmailCampaign,
+	EmailCampaignAudience,
+	EmailCampaignStatus,
+	EmailCampaignSummary
+} from './validation.ts';
+
+type DatabaseAudienceProfile = Omit<AudienceProfile, 'canJoinLocalEvents' | 'isBasedOnGTA' | 'teamIds'> & {
+	canJoinLocalEvents: number,
+	isBasedOnGTA: number,
+	teamIds: string
+};
+
+export interface CampaignRecipient {
+	id: string;
+	profileId: string;
+	email: string;
+	name: string;
+}
+
+const ERROR_MESSAGE_MAX_LENGTH = 1000;
+
+function transformAudienceProfile(profile: DatabaseAudienceProfile): AudienceProfile {
+	return {
+		...profile,
+		canJoinLocalEvents: Boolean(profile.canJoinLocalEvents),
+		isBasedOnGTA: Boolean(profile.isBasedOnGTA),
+		teamIds: JSON.parse(profile.teamIds) as string[]
+	};
+}
+
+const audienceProfileSelect = `
+	SELECT
+		profile.id,
+		profile.name,
+		access.email,
+		access.accessLevel,
+		access.profileStatus,
+		profile.isBasedOnGTA,
+		profile.canJoinLocalEvents,
+		(
+			SELECT json_group_array(role.teamId)
+			FROM ${DBTables.ROLE} AS role
+			INNER JOIN ${DBTables.TEAM} AS team ON team.id = role.teamId
+			WHERE
+				role.profileId = profile.id
+				AND role.deletedAt IS NULL
+				AND team.deletedAt IS NULL
+		) AS teamIds
+	FROM ${DBTables.PROFILE} AS profile
+	INNER JOIN ${DBTables.ACCESS} AS access ON access.id = profile.id
+`;
+
+export async function getAudienceOptions(database: D1Database) {
+	const [profilesResult, teamsResult] = await database.batch([
+		database.prepare(`
+			${audienceProfileSelect}
+			WHERE access.activatedAt IS NOT NULL AND access.deletedAt IS NULL
+			ORDER BY profile.name COLLATE NOCASE
+		`),
+		database.prepare(`
+			SELECT
+				team.id,
+				team.name,
+				COUNT(DISTINCT CASE
+					WHEN role.deletedAt IS NULL AND access.activatedAt IS NOT NULL AND access.deletedAt IS NULL
+					THEN role.profileId
+				END) AS memberCount
+			FROM ${DBTables.TEAM} AS team
+			LEFT JOIN ${DBTables.ROLE} AS role ON role.teamId = team.id
+			LEFT JOIN ${DBTables.ACCESS} AS access ON access.id = role.profileId
+			WHERE team.deletedAt IS NULL
+			GROUP BY team.id, team.name
+			ORDER BY team.name COLLATE NOCASE
+		`)
+	]);
+
+	return {
+		profiles: (profilesResult?.results as DatabaseAudienceProfile[] | undefined ?? []).map(transformAudienceProfile),
+		teams: teamsResult?.results as { id: string, name: string, memberCount: number }[] | undefined ?? []
+	};
+}
+
+function placeholders(values: unknown[]) {
+	return new Array(values.length).fill('?').join(', ');
+}
+
+export async function resolveAudience(database: D1Database, audience: EmailCampaignAudience): Promise<AudienceProfile[]> {
+	const whereClauses = [
+		'access.activatedAt IS NOT NULL',
+		'access.deletedAt IS NULL'
+	];
+	const bindings: unknown[] = [];
+
+	if (audience.mode === 'selected') {
+		const selectedClauses: string[] = [];
+
+		if (audience.profileIds.length > 0) {
+			selectedClauses.push(`profile.id IN (${placeholders(audience.profileIds)})`);
+			bindings.push(...audience.profileIds);
+		}
+
+		if (audience.teamIds.length > 0) {
+			selectedClauses.push(`EXISTS (
+				SELECT 1
+				FROM ${DBTables.ROLE} AS selectedRole
+				INNER JOIN ${DBTables.TEAM} AS selectedTeam ON selectedTeam.id = selectedRole.teamId
+				WHERE
+					selectedRole.profileId = profile.id
+					AND selectedRole.teamId IN (${placeholders(audience.teamIds)})
+					AND selectedRole.deletedAt IS NULL
+					AND selectedTeam.deletedAt IS NULL
+			)`);
+			bindings.push(...audience.teamIds);
+		}
+
+		whereClauses.push(`(${selectedClauses.join(' OR ')})`);
+	}
+
+	if (audience.accessLevels.length > 0) {
+		whereClauses.push(`access.accessLevel IN (${placeholders(audience.accessLevels)})`);
+		bindings.push(...audience.accessLevels);
+	}
+
+	if (audience.profileStatuses.length > 0) {
+		whereClauses.push(`access.profileStatus IN (${placeholders(audience.profileStatuses)})`);
+		bindings.push(...audience.profileStatuses);
+	}
+
+	if (audience.isBasedOnGTA !== undefined) {
+		whereClauses.push('profile.isBasedOnGTA = ?');
+		bindings.push(Number(audience.isBasedOnGTA));
+	}
+
+	if (audience.canJoinLocalEvents !== undefined) {
+		whereClauses.push('profile.canJoinLocalEvents = ?');
+		bindings.push(Number(audience.canJoinLocalEvents));
+	}
+
+	const { results } = await database.prepare(`
+		${audienceProfileSelect}
+		WHERE ${whereClauses.join('\n\t\t\tAND ')}
+		ORDER BY profile.name COLLATE NOCASE
+	`).bind(...bindings).run<DatabaseAudienceProfile>();
+
+	return results.map(transformAudienceProfile);
+}
+
+export async function getCampaignByIdempotencyKey(database: D1Database, idempotencyKey: string) {
+	return database.prepare(`
+		SELECT
+			campaign.id,
+			campaign.subject,
+			campaign.status,
+			campaign.recipientCount,
+			campaign.sentCount,
+			campaign.failedCount,
+			campaign.insertedAt,
+			campaign.sentAt,
+			profile.name AS createdByName
+		FROM ${DBTables.EMAIL_CAMPAIGN} AS campaign
+		INNER JOIN ${DBTables.PROFILE} AS profile ON profile.id = campaign.createdBy
+		WHERE campaign.idempotencyKey = ?
+		LIMIT 1
+	`).bind(idempotencyKey).first<EmailCampaignSummary>();
+}
+
+export async function insertCampaign(
+	database: D1Database,
+	createdBy: string,
+	data: CreateEmailCampaign,
+	recipients: AudienceProfile[]
+) {
+	const { id: campaignId, schemaVersion, happenedAt, insertedAt } = generateBaseDBfields();
+	const recipientRows: CampaignRecipient[] = recipients.map(({ id: profileId, email, name }) => ({
+		id: crypto.randomUUID(),
+		profileId,
+		email,
+		name
+	}));
+
+	await database.batch([
+		database.prepare(`
+			INSERT INTO ${DBTables.EMAIL_CAMPAIGN} (
+				id, schemaVersion, createdBy, subject, message, audienceCriteria,
+				idempotencyKey, status, recipientCount, happenedAt, insertedAt
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, 'sending', ?, ?, ?)
+		`).bind(
+			campaignId,
+			schemaVersion,
+			createdBy,
+			data.subject,
+			data.message,
+			JSON.stringify(data.audience),
+			data.idempotencyKey,
+			recipients.length,
+			happenedAt,
+			insertedAt
+		),
+		...recipientRows.map(({ id, profileId, email }) =>
+			database.prepare(`
+			INSERT INTO ${DBTables.EMAIL_CAMPAIGN_RECIPIENT} (
+				id, campaignId, profileId, email, status, insertedAt
+			)
+			VALUES (?, ?, ?, ?, 'pending', ?)
+		`).bind(id, campaignId, profileId, email, insertedAt)
+		)
+	]);
+
+	return { campaignId, recipients: recipientRows };
+}
+
+export async function updateRecipientDelivery(
+	database: D1Database,
+	recipientId: string,
+	status: 'failed' | 'sent',
+	providerMessageId?: string,
+	errorMessage?: string
+) {
+	return database.prepare(`
+		UPDATE ${DBTables.EMAIL_CAMPAIGN_RECIPIENT}
+		SET status = ?, providerMessageId = ?, errorMessage = ?, attemptedAt = ?
+		WHERE id = ?
+		`).bind(status, providerMessageId ?? null, errorMessage?.slice(0, ERROR_MESSAGE_MAX_LENGTH) ?? null, new Date().toISOString(), recipientId).run();
+}
+
+export async function finishCampaign(
+	database: D1Database,
+	campaignId: string,
+	status: EmailCampaignStatus,
+	sentCount: number,
+	failedCount: number
+) {
+	return database.prepare(`
+		UPDATE ${DBTables.EMAIL_CAMPAIGN}
+		SET status = ?, sentCount = ?, failedCount = ?, sentAt = ?
+		WHERE id = ?
+	`).bind(status, sentCount, failedCount, new Date().toISOString(), campaignId).run();
+}
+
+export async function getRecentCampaigns(database: D1Database) {
+	const { results } = await database.prepare(`
+		SELECT
+			campaign.id,
+			campaign.subject,
+			campaign.status,
+			campaign.recipientCount,
+			campaign.sentCount,
+			campaign.failedCount,
+			campaign.insertedAt,
+			campaign.sentAt,
+			profile.name AS createdByName
+		FROM ${DBTables.EMAIL_CAMPAIGN} AS campaign
+		INNER JOIN ${DBTables.PROFILE} AS profile ON profile.id = campaign.createdBy
+		ORDER BY campaign.insertedAt DESC
+		LIMIT 20
+	`).run<EmailCampaignSummary>();
+
+	return results;
+}

--- a/api/src/routes/email-campaign/index.failure.test.ts
+++ b/api/src/routes/email-campaign/index.failure.test.ts
@@ -1,0 +1,107 @@
+import { applyD1Migrations, env } from 'cloudflare:test';
+import { assert, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import type * as EmailModule from '../../email/index.ts';
+import { StatusCodes } from '../../utils/responses.ts';
+
+// Force the provider to fail so the delivery/finalize paths are exercised. Local mode
+// (ARE_EMAILS_LOCAL_ONLY) otherwise always "succeeds", so failures can't happen without this.
+const { sendMock } = vi.hoisted(() => ({ sendMock: vi.fn() }));
+vi.mock('../../email/index.ts', async (importOriginal) => ({
+	...(await importOriginal<typeof EmailModule>()),
+	sendCommunityNotificationEmail: sendMock
+}));
+
+// Imported after vi.mock so the route picks up the mocked email module.
+const { app } = await import('../../index.ts');
+
+const ORGANIZER_ID = '3c5123c0-8548-4a02-a83c-32e9ce67eae8';
+
+beforeAll(async () => {
+	await applyD1Migrations(env.Database, env.TEST_MIGRATIONS);
+});
+
+beforeEach(async () => {
+	await env.Database.exec(env.SEED_SQL);
+	const sessionKeys = await env.SessionTokens.list();
+	await Promise.all(sessionKeys.keys.map(async ({ name }) => env.SessionTokens.delete(name)));
+	sendMock.mockReset();
+});
+
+async function signIn(email: string, password: string) {
+	const response = await app.request('/api/auth/sign-in', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ email, password })
+	}, env);
+	const setCookie = response.headers.get('set-cookie');
+
+	expect(response.status).toBe(StatusCodes.OKAY);
+	assert(setCookie, 'Sign-in response should include a cookie.');
+	const [cookie] = setCookie.split(';');
+	assert(cookie, 'Session cookie should exist.');
+	return cookie;
+}
+
+function sendCampaign(cookie: string, audience: unknown) {
+	return app.request('/api/email-campaigns', {
+		method: 'POST',
+		headers: { 'Cookie': cookie, 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			subject: 'Community update',
+			message: 'This is a test community notification.',
+			audience,
+			idempotencyKey: crypto.randomUUID()
+		})
+	}, env);
+}
+
+describe('Email campaign failure handling', () => {
+	test('marks a campaign failed (never stuck on sending) when every send fails', async () => {
+		sendMock.mockResolvedValue({ data: null, error: { message: 'Simulated provider failure' } });
+		const cookie = await signIn('king.arthur@camelot.uk', 'H0lyGr@il42!L0rd');
+
+		const response = await sendCampaign(cookie, { mode: 'selected', profileIds: [ORGANIZER_ID] });
+		const campaign = await response.json<{ status: string, sentCount: number, failedCount: number }>();
+
+		expect(response.status).toBe(StatusCodes.CREATED);
+		expect(campaign).toMatchObject({ status: 'failed', sentCount: 0, failedCount: 1 });
+		expect(campaign.status).not.toBe('sending');
+	});
+
+	test('marks a campaign partially-failed when some sends fail', async () => {
+		let call = 0;
+		sendMock.mockImplementation(() => {
+			call += 1;
+			return Promise.resolve(
+				call % 2 === 0 ?
+					{ data: null, error: { message: 'Simulated provider failure' } } :
+					{ data: { id: crypto.randomUUID() }, error: null }
+			);
+		});
+		const cookie = await signIn('king.arthur@camelot.uk', 'H0lyGr@il42!L0rd');
+
+		const response = await sendCampaign(cookie, { mode: 'all' });
+		const campaign = await response.json<{ status: string, sentCount: number, failedCount: number }>();
+
+		expect(response.status).toBe(StatusCodes.CREATED);
+		expect(campaign.status).toBe('partially-failed');
+		expect(campaign.sentCount).toBeGreaterThan(0);
+		expect(campaign.failedCount).toBeGreaterThan(0);
+	});
+
+	test('records a failed recipient even if the provider throws', async () => {
+		sendMock.mockRejectedValue(new Error('Network down'));
+		const cookie = await signIn('king.arthur@camelot.uk', 'H0lyGr@il42!L0rd');
+
+		const response = await sendCampaign(cookie, { mode: 'selected', profileIds: [ORGANIZER_ID] });
+		const campaign = await response.json<{ id: string, status: string }>();
+		const recipient = await env.Database
+			.prepare('SELECT status, errorMessage FROM email_campaign_recipient WHERE campaignId = ?')
+			.bind(campaign.id)
+			.first<{ status: string, errorMessage: string }>();
+
+		expect(campaign.status).toBe('failed');
+		expect(recipient?.status).toBe('failed');
+		expect(recipient?.errorMessage).toBe('Network down');
+	});
+});

--- a/api/src/routes/email-campaign/index.test.ts
+++ b/api/src/routes/email-campaign/index.test.ts
@@ -1,0 +1,87 @@
+import { applyD1Migrations, env } from 'cloudflare:test';
+import { assert, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import { app } from '../../index.ts';
+import { StatusCodes } from '../../utils/responses.ts';
+
+const ORGANIZER_ID = '3c5123c0-8548-4a02-a83c-32e9ce67eae8';
+
+beforeAll(async () => {
+	await applyD1Migrations(env.Database, env.TEST_MIGRATIONS);
+});
+
+beforeEach(async () => {
+	await env.Database.exec(env.SEED_SQL);
+	const sessionKeys = await env.SessionTokens.list();
+	await Promise.all(sessionKeys.keys.map(async ({ name }) => env.SessionTokens.delete(name)));
+});
+
+async function signIn(email: string, password: string) {
+	const response = await app.request('/api/auth/sign-in', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ email, password })
+	}, env);
+	const setCookie = response.headers.get('set-cookie');
+
+	expect(response.status).toBe(StatusCodes.OKAY);
+	assert(setCookie, 'Sign-in response should include a cookie.');
+	const [cookie] = setCookie.split(';');
+	assert(cookie, 'Session cookie should exist.');
+	return cookie;
+}
+
+describe('Email campaign routes', () => {
+	test('allows organizers to load audience options', async () => {
+		const cookie = await signIn('king.arthur@camelot.uk', 'H0lyGr@il42!L0rd');
+		const response = await app.request('/api/email-campaigns/audience-options', {
+			headers: { Cookie: cookie }
+		}, env);
+		const data = await response.json<{ profiles: unknown[], teams: unknown[] }>();
+
+		expect(response.status).toBe(StatusCodes.OKAY);
+		expect(data.profiles.length).toBeGreaterThan(0);
+		expect(data.teams.length).toBeGreaterThan(0);
+	});
+
+	test('does not allow volunteers to preview private recipient data', async () => {
+		const cookie = await signIn('sir.robin@cowardly.co', 'RunAway!1234Run');
+		const response = await app.request('/api/email-campaigns/preview', {
+			method: 'POST',
+			headers: { 'Cookie': cookie, 'Content-Type': 'application/json' },
+			body: JSON.stringify({ audience: { mode: 'all' } })
+		}, env);
+
+		expect(response.status).toBe(StatusCodes.FORBIDDEN);
+	});
+
+	test('sends once and returns the same campaign for a repeated idempotency key', async () => {
+		const cookie = await signIn('king.arthur@camelot.uk', 'H0lyGr@il42!L0rd');
+		const idempotencyKey = crypto.randomUUID();
+		const body = JSON.stringify({
+			subject: 'Community update',
+			message: 'This is a test community notification.',
+			audience: { mode: 'selected', profileIds: [ORGANIZER_ID] },
+			idempotencyKey
+		});
+		const request = async () =>
+			app.request('/api/email-campaigns', {
+				method: 'POST',
+				headers: { 'Cookie': cookie, 'Content-Type': 'application/json' },
+				body
+			}, env);
+
+		const firstResponse = await request();
+		const firstCampaign = await firstResponse.json<{ id: string, sentCount: number, failedCount: number }>();
+		const repeatedResponse = await request();
+		const repeatedCampaign = await repeatedResponse.json<{ id: string }>();
+		const storedCount = await env.Database.prepare('SELECT COUNT(*) AS count FROM email_campaign WHERE idempotencyKey = ?')
+			.bind(idempotencyKey)
+			.first<{ count: number }>();
+
+		expect(firstResponse.status).toBe(StatusCodes.CREATED);
+		expect(firstCampaign).toMatchObject({ sentCount: 1, failedCount: 0 });
+		expect(repeatedResponse.status).toBe(StatusCodes.OKAY);
+		expect(repeatedCampaign.id).toBe(firstCampaign.id);
+		expect(storedCount?.count).toBe(1);
+	});
+});

--- a/api/src/routes/email-campaign/index.ts
+++ b/api/src/routes/email-campaign/index.ts
@@ -1,0 +1,257 @@
+import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
+import { z } from 'zod';
+import { sendCommunityNotificationEmail } from '../../email/index.ts';
+import { authorizeOrganizer } from '../../middleware/access.ts';
+import { authMiddleware } from '../../middleware/auth.ts';
+import { bodySizeCheck } from '../../middleware/body-size.ts';
+import { getSession } from '../../utils/auth.ts';
+import {
+	StatusCodes,
+	type StatusResponse,
+	statusResponseFormatter,
+	StatusResponseSchema
+} from '../../utils/responses.ts';
+import {
+	finishCampaign,
+	getAudienceOptions,
+	getCampaignByIdempotencyKey,
+	getRecentCampaigns,
+	insertCampaign,
+	resolveAudience,
+	updateRecipientDelivery
+} from './data.ts';
+import {
+	AudienceOptionsSchema,
+	CreateEmailCampaignSchema,
+	EmailCampaignPreviewSchema,
+	type EmailCampaignStatus,
+	EmailCampaignSummarySchema,
+	PreviewEmailCampaignSchema
+} from './validation.ts';
+
+const MAX_CONCURRENT_EMAILS = 5;
+// Each recipient costs ~2 subrequests (send + status write). 400 keeps a campaign
+// well under the Worker's 1000-subrequest-per-request limit, so it finishes in one
+// request without a queue. Revisit if the community outgrows this.
+const MAX_RECIPIENTS_PER_CAMPAIGN = 400;
+
+export const emailCampaignRoutes = new OpenAPIHono<EnvironmentBindings>({
+	defaultHook: statusResponseFormatter
+});
+
+emailCampaignRoutes.openapi(
+	createRoute({
+		method: 'get',
+		path: '/audience-options',
+		operationId: 'List email campaign audience options',
+		summary: 'List eligible email recipients and teams',
+		description: 'Lists active community members and teams available to organizers when composing an email campaign.',
+		tags: ['Email Campaigns'],
+		responses: {
+			[StatusCodes.OKAY]: {
+				description: 'Successful response',
+				content: { 'application/json': { schema: AudienceOptionsSchema } }
+			},
+			[StatusCodes.UNAUTHORIZED]: {
+				description: 'Authentication required',
+				content: { 'application/json': { schema: StatusResponseSchema } }
+			},
+			[StatusCodes.FORBIDDEN]: {
+				description: 'Organizer access required',
+				content: { 'application/json': { schema: StatusResponseSchema } }
+			}
+		},
+		middleware: [authMiddleware, authorizeOrganizer] as const
+	}),
+	async (context) => context.json(await getAudienceOptions(context.env.Database), StatusCodes.OKAY)
+);
+
+emailCampaignRoutes.openapi(
+	createRoute({
+		method: 'post',
+		path: '/preview',
+		operationId: 'Preview email campaign audience',
+		summary: 'Resolve and preview campaign recipients',
+		description: 'Returns the exact deduplicated recipients matching the selected audience and filters.',
+		tags: ['Email Campaigns'],
+		request: {
+			body: { content: { 'application/json': { schema: PreviewEmailCampaignSchema } }, required: true }
+		},
+		responses: {
+			[StatusCodes.OKAY]: {
+				description: 'Successful response',
+				content: { 'application/json': { schema: EmailCampaignPreviewSchema } }
+			},
+			[StatusCodes.UNAUTHORIZED]: {
+				description: 'Authentication required',
+				content: { 'application/json': { schema: StatusResponseSchema } }
+			},
+			[StatusCodes.FORBIDDEN]: {
+				description: 'Organizer access required',
+				content: { 'application/json': { schema: StatusResponseSchema } }
+			}
+		},
+		middleware: [bodySizeCheck, authMiddleware, authorizeOrganizer] as const
+	}),
+	async (context) => {
+		const recipients = await resolveAudience(context.env.Database, context.req.valid('json').audience);
+
+		return context.json({
+			count: recipients.length,
+			recipients: recipients.map(({ id, name, email }) => ({ id, name, email }))
+		}, StatusCodes.OKAY);
+	}
+);
+
+emailCampaignRoutes.openapi(
+	createRoute({
+		method: 'get',
+		path: '/',
+		operationId: 'List recent email campaigns',
+		summary: 'List recent email campaigns',
+		description: 'Lists the twenty most recent community email campaigns.',
+		tags: ['Email Campaigns'],
+		responses: {
+			[StatusCodes.OKAY]: {
+				description: 'Successful response',
+				content: { 'application/json': { schema: z.object({ data: z.array(EmailCampaignSummarySchema) }) } }
+			},
+			[StatusCodes.UNAUTHORIZED]: {
+				description: 'Authentication required',
+				content: { 'application/json': { schema: StatusResponseSchema } }
+			},
+			[StatusCodes.FORBIDDEN]: {
+				description: 'Organizer access required',
+				content: { 'application/json': { schema: StatusResponseSchema } }
+			}
+		},
+		middleware: [authMiddleware, authorizeOrganizer] as const
+	}),
+	async (context) => context.json({ data: await getRecentCampaigns(context.env.Database) }, StatusCodes.OKAY)
+);
+
+emailCampaignRoutes.openapi(
+	createRoute({
+		method: 'post',
+		path: '/',
+		operationId: 'Send email campaign',
+		summary: 'Send a community email campaign',
+		description: 'Snapshots the selected recipients, sends an individual email to each one, and stores each result.',
+		tags: ['Email Campaigns'],
+		request: {
+			body: { content: { 'application/json': { schema: CreateEmailCampaignSchema } }, required: true }
+		},
+		responses: {
+			[StatusCodes.CREATED]: {
+				description: 'Campaign sent',
+				content: { 'application/json': { schema: EmailCampaignSummarySchema } }
+			},
+			[StatusCodes.OKAY]: {
+				description: 'A campaign with the same idempotency key was already submitted',
+				content: { 'application/json': { schema: EmailCampaignSummarySchema } }
+			},
+			[StatusCodes.UNPROCESSABLE_CONTENT]: {
+				description: 'No eligible recipients matched the audience',
+				content: { 'application/json': { schema: StatusResponseSchema } }
+			},
+			[StatusCodes.UNAUTHORIZED]: {
+				description: 'Authentication required',
+				content: { 'application/json': { schema: StatusResponseSchema } }
+			},
+			[StatusCodes.FORBIDDEN]: {
+				description: 'Organizer access required',
+				content: { 'application/json': { schema: StatusResponseSchema } }
+			}
+		},
+		middleware: [bodySizeCheck, authMiddleware, authorizeOrganizer] as const
+	}),
+	async (context) => {
+		const data = context.req.valid('json');
+		const existingCampaign = await getCampaignByIdempotencyKey(context.env.Database, data.idempotencyKey);
+
+		if (existingCampaign) {
+			return context.json(existingCampaign, StatusCodes.OKAY);
+		}
+
+		const recipients = await resolveAudience(context.env.Database, data.audience);
+
+		if (recipients.length === 0) {
+			return context.json(
+				{ message: 'No active community members match the selected audience.' } satisfies StatusResponse,
+				StatusCodes.UNPROCESSABLE_CONTENT
+			);
+		}
+
+		if (recipients.length > MAX_RECIPIENTS_PER_CAMPAIGN) {
+			return context.json(
+				{ message: `This audience has ${recipients.length} recipients. Please narrow it to ${MAX_RECIPIENTS_PER_CAMPAIGN} or fewer.` } satisfies StatusResponse,
+				StatusCodes.UNPROCESSABLE_CONTENT
+			);
+		}
+
+		const { id: createdBy } = getSession(context);
+		const { campaignId, recipients: campaignRecipients } = await insertCampaign(context.env.Database, createdBy, data, recipients);
+		let sentCount = 0;
+		let failedCount = 0;
+
+		try {
+			for (let index = 0; index < campaignRecipients.length; index += MAX_CONCURRENT_EMAILS) {
+				const recipientBatch = campaignRecipients.slice(index, index + MAX_CONCURRENT_EMAILS);
+
+				const batchResults = await Promise.all(recipientBatch.map(async (recipient) => {
+					let providerMessageId: string | undefined;
+					let errorMessage: string | undefined;
+
+					try {
+						const response = await sendCommunityNotificationEmail(context, {
+							apiKey: context.env.RESEND_API_KEY,
+							email: recipient.email,
+							message: data.message,
+							senderEmail: context.env.SENDER_EMAIL,
+							subject: data.subject
+						});
+
+						providerMessageId = response.data?.id;
+						if (response.error || !providerMessageId) {
+							errorMessage = response.error?.message ?? 'Email provider did not return a message ID.';
+						}
+					} catch (error) {
+						errorMessage = error instanceof Error ? error.message : 'Unknown email provider error.';
+					}
+
+					// The status write is guarded too: a failed DB update must not abort the whole batch.
+					try {
+						if (errorMessage) {
+							await updateRecipientDelivery(context.env.Database, recipient.id, 'failed', undefined, errorMessage);
+							return false;
+						}
+
+						await updateRecipientDelivery(context.env.Database, recipient.id, 'sent', providerMessageId);
+						return true;
+					} catch {
+						return false;
+					}
+				}));
+
+				sentCount += batchResults.filter(Boolean).length;
+				failedCount += batchResults.filter((wasSent) => !wasSent).length;
+			}
+		} finally {
+			// Always finalize so a campaign never stays stuck in 'sending', even if the loop throws.
+			let status: EmailCampaignStatus = 'partially-failed';
+			if (failedCount === 0 && sentCount > 0) {
+				status = 'sent';
+			} else if (sentCount === 0) {
+				status = 'failed';
+			}
+			await finishCampaign(context.env.Database, campaignId, status, sentCount, failedCount);
+		}
+		const campaign = await getCampaignByIdempotencyKey(context.env.Database, data.idempotencyKey);
+
+		if (!campaign) {
+			throw new Error('Campaign was sent but its summary could not be loaded.');
+		}
+
+		return context.json(campaign, StatusCodes.CREATED);
+	}
+);

--- a/api/src/routes/email-campaign/validation.test.ts
+++ b/api/src/routes/email-campaign/validation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest';
+import { CreateEmailCampaignSchema, EmailCampaignAudienceSchema } from './validation.ts';
+
+const TEAM_ID = '70ca1ff2-6ab6-4533-ae79-203f5b08742c';
+
+describe('Email campaign validation', () => {
+	test('accepts all active community members with optional filters', () => {
+		const result = EmailCampaignAudienceSchema.safeParse({
+			mode: 'all',
+			accessLevels: ['volunteer'],
+			isBasedOnGTA: true
+		});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.teamIds).toEqual([]);
+			expect(result.data.profileIds).toEqual([]);
+		}
+	});
+
+	test('requires a team or individual for a selected audience', () => {
+		const result = EmailCampaignAudienceSchema.safeParse({ mode: 'selected' });
+
+		expect(result.success).toBe(false);
+	});
+
+	test('accepts one or more selected teams', () => {
+		const result = EmailCampaignAudienceSchema.safeParse({
+			mode: 'selected',
+			teamIds: [TEAM_ID]
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects an audience with too many selected ids', () => {
+		const profileIds = Array.from({ length: 501 }, (_, index) => `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`);
+		const result = EmailCampaignAudienceSchema.safeParse({ mode: 'selected', profileIds });
+
+		expect(result.success).toBe(false);
+	});
+
+	test('requires a subject and message', () => {
+		const result = CreateEmailCampaignSchema.safeParse({
+			subject: ' ',
+			message: '',
+			audience: { mode: 'all' },
+			idempotencyKey: crypto.randomUUID()
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	test('accepts a complete campaign', () => {
+		const result = CreateEmailCampaignSchema.safeParse({
+			subject: 'Community update',
+			message: 'Hello volunteers!',
+			audience: { mode: 'selected', teamIds: [TEAM_ID] },
+			idempotencyKey: crypto.randomUUID()
+		});
+
+		expect(result.success).toBe(true);
+	});
+});

--- a/api/src/routes/email-campaign/validation.ts
+++ b/api/src/routes/email-campaign/validation.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import { LONG_TEXT_SIZE_IN_CHAR } from '../../middleware/body-size.ts';
+import { AccessLevelSchema } from '../../utils/auth.ts';
+import { IdSchema } from '../../utils/db.ts';
+import { ProfileStatusSchema } from '../auth/validation.ts';
+import { ProfileSchema } from '../profile/validation.ts';
+
+const SUBJECT_MAX_LENGTH = 200;
+// Bounds the SQL `IN (...)` clause built from these arrays; a normal UI selection never approaches this.
+const MAX_AUDIENCE_IDS = 500;
+
+export const EmailCampaignAudienceSchema = z.object({
+	mode: z.enum(['all', 'selected']),
+	teamIds: z.array(IdSchema).max(MAX_AUDIENCE_IDS).default([]),
+	profileIds: z.array(IdSchema).max(MAX_AUDIENCE_IDS).default([]),
+	accessLevels: z.array(AccessLevelSchema).default([]),
+	profileStatuses: z.array(ProfileStatusSchema).default([]),
+	isBasedOnGTA: z.boolean().optional(),
+	canJoinLocalEvents: z.boolean().optional()
+}).refine(
+	({ mode, profileIds, teamIds }) => mode === 'all' || profileIds.length > 0 || teamIds.length > 0,
+	{ message: 'Select at least one team or individual volunteer.', path: ['mode'] }
+);
+
+export type EmailCampaignAudience = z.infer<typeof EmailCampaignAudienceSchema>;
+
+export const PreviewEmailCampaignSchema = z.object({ audience: EmailCampaignAudienceSchema });
+
+export const CreateEmailCampaignSchema = z.object({
+	subject: z.string().trim().min(1, 'Subject is required.').max(SUBJECT_MAX_LENGTH),
+	message: z.string().trim().min(1, 'Message is required.').max(LONG_TEXT_SIZE_IN_CHAR),
+	audience: EmailCampaignAudienceSchema,
+	idempotencyKey: z.uuid()
+});
+
+export type CreateEmailCampaign = z.infer<typeof CreateEmailCampaignSchema>;
+
+export const AudienceProfileSchema = z.object({
+	id: IdSchema,
+	name: ProfileSchema.shape.name,
+	email: ProfileSchema.shape.email,
+	accessLevel: AccessLevelSchema,
+	profileStatus: ProfileStatusSchema,
+	isBasedOnGTA: z.boolean(),
+	canJoinLocalEvents: z.boolean(),
+	teamIds: z.array(IdSchema)
+});
+
+export type AudienceProfile = z.infer<typeof AudienceProfileSchema>;
+
+export const AudienceTeamSchema = z.object({
+	id: IdSchema,
+	name: z.string(),
+	memberCount: z.number().int().nonnegative()
+});
+
+export const AudienceOptionsSchema = z.object({
+	profiles: z.array(AudienceProfileSchema),
+	teams: z.array(AudienceTeamSchema)
+});
+
+export const EmailCampaignPreviewSchema = z.object({
+	count: z.number().int().nonnegative(),
+	recipients: z.array(AudienceProfileSchema.pick({ id: true, name: true, email: true }))
+});
+
+export const EmailCampaignStatusSchema = z.enum(['sending', 'sent', 'partially-failed', 'failed']);
+
+export type EmailCampaignStatus = z.infer<typeof EmailCampaignStatusSchema>;
+
+export const EmailCampaignSummarySchema = z.object({
+	id: IdSchema,
+	subject: z.string(),
+	status: EmailCampaignStatusSchema,
+	recipientCount: z.number().int().nonnegative(),
+	sentCount: z.number().int().nonnegative(),
+	failedCount: z.number().int().nonnegative(),
+	insertedAt: z.iso.datetime({ offset: true }),
+	sentAt: z.iso.datetime({ offset: true }).nullable().optional(),
+	createdByName: z.string()
+});
+
+export type EmailCampaignSummary = z.infer<typeof EmailCampaignSummarySchema>;

--- a/api/src/utils/db.ts
+++ b/api/src/utils/db.ts
@@ -11,7 +11,9 @@ export const DBTables = {
 	PROFILE_SKILLS: 'profile_skills',
 	PROFILE_LINKS: 'profile_links',
 	EVENT_LOG: 'event_log',
-	DOCUMENTS: 'documents'
+	DOCUMENTS: 'documents',
+	EMAIL_CAMPAIGN: 'email_campaign',
+	EMAIL_CAMPAIGN_RECIPIENT: 'email_campaign_recipient'
 } as const;
 
 export const IdSchema = z.uuid().describe('the entity UUID.');

--- a/db/migrations/0008_create-email-campaigns.sql
+++ b/db/migrations/0008_create-email-campaigns.sql
@@ -1,0 +1,45 @@
+-- Migration number: 0008
+
+CREATE TABLE IF NOT EXISTS email_campaign (
+	id TEXT NOT NULL UNIQUE COLLATE BINARY,
+	schemaVersion INTEGER NOT NULL DEFAULT 1,
+	createdBy TEXT NOT NULL COLLATE BINARY,
+	subject TEXT NOT NULL,
+	message TEXT NOT NULL,
+	audienceCriteria TEXT NOT NULL,
+	idempotencyKey TEXT NOT NULL UNIQUE COLLATE BINARY,
+	status TEXT NOT NULL DEFAULT 'sending' CHECK(status IN ('sending', 'sent', 'partially-failed', 'failed')),
+	recipientCount INTEGER NOT NULL DEFAULT 0,
+	sentCount INTEGER NOT NULL DEFAULT 0,
+	failedCount INTEGER NOT NULL DEFAULT 0,
+	happenedAt DATETIME NOT NULL,
+	insertedAt DATETIME NOT NULL,
+	sentAt DATETIME DEFAULT NULL,
+
+	PRIMARY KEY (id),
+	FOREIGN KEY (createdBy) REFERENCES profile(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_campaign_created_by ON email_campaign (createdBy);
+CREATE INDEX IF NOT EXISTS idx_email_campaign_inserted_at ON email_campaign (insertedAt);
+
+CREATE TABLE IF NOT EXISTS email_campaign_recipient (
+	id TEXT NOT NULL UNIQUE COLLATE BINARY,
+	campaignId TEXT NOT NULL COLLATE BINARY,
+	profileId TEXT NOT NULL COLLATE BINARY,
+	email TEXT NOT NULL,
+	status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'sent', 'failed')),
+	providerMessageId TEXT DEFAULT NULL,
+	errorMessage TEXT DEFAULT NULL,
+	insertedAt DATETIME NOT NULL,
+	attemptedAt DATETIME DEFAULT NULL,
+
+	PRIMARY KEY (id),
+	FOREIGN KEY (campaignId) REFERENCES email_campaign(id),
+	FOREIGN KEY (profileId) REFERENCES profile(id),
+	UNIQUE(campaignId, profileId)
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_campaign_recipient_campaign ON email_campaign_recipient (campaignId);
+CREATE INDEX IF NOT EXISTS idx_email_campaign_recipient_profile ON email_campaign_recipient (profileId);
+CREATE INDEX IF NOT EXISTS idx_email_campaign_recipient_status ON email_campaign_recipient (campaignId, status);

--- a/src/components/AuthenticatedLayout/AuthenticatedLayout.css
+++ b/src/components/AuthenticatedLayout/AuthenticatedLayout.css
@@ -39,6 +39,23 @@
 	width: 2rem;
 }
 
+.authenticated-layout .inner-header .notification-link {
+	align-items: center;
+	border-radius: var(--rounded-full);
+	display: flex;
+	height: 2rem;
+	justify-content: center;
+	width: 2rem;
+}
+
+.authenticated-layout .inner-header .notification-link[aria-current='page'] { background-color: var(--color-accent); }
+
+.authenticated-layout .inner-header .notification-link[aria-current='page'] .notification-bell {
+	filter: brightness(0) invert(1);
+	height: 1.25rem;
+	width: 1.25rem;
+}
+
 .authenticated-layout .sidebar-left {
 	border-right: var(--border);
 	box-sizing: border-box;
@@ -294,5 +311,15 @@
 	.authenticated-layout .inner-header .notification-bell {
 		height: 1.5rem;
 		width: 1.5rem;
+	}
+
+	.authenticated-layout .inner-header .notification-link {
+		height: 1.5rem;
+		width: 1.5rem;
+	}
+
+	.authenticated-layout .inner-header .notification-link[aria-current='page'] .notification-bell {
+		height: 1rem;
+		width: 1rem;
 	}
 }

--- a/src/components/AuthenticatedLayout/AuthenticatedLayout.tsx
+++ b/src/components/AuthenticatedLayout/AuthenticatedLayout.tsx
@@ -3,7 +3,7 @@ import './AuthenticatedLayout.css';
 import { useAuth } from '../../context/AuthContext.tsx';
 import { handleLogOut } from '../../utilities/handleLogOut.ts';
 
-type ActivePage = 'community' | 'profile' | 'teams' | 'volunteer';
+type ActivePage = 'community' | 'notifications' | 'profile' | 'teams' | 'volunteer';
 
 interface Props {
 	activePage?: ActivePage;
@@ -82,8 +82,13 @@ const AuthenticatedLayout = ({ activePage, children, className, mainClassName }:
 					</a>
 					<div className='inner-header'>
 						<img className='small-avatar' src={avatar} alt='Small User Avatar' />
-						<a href='/pages/notifications/'>
-							<img className='notification-bell' src='/notification-bell.png' alt='Notification bell icon' />
+						<a
+							className='notification-link'
+							href='/pages/notifications/'
+							aria-label='Notifications'
+							aria-current={activePage === 'notifications' ? 'page' : undefined}
+						>
+							<img className='notification-bell' src='/notification-bell.png' alt='' />
 						</a>
 					</div>
 				</header>

--- a/src/components/EmailCampaignComposer/EmailCampaignComposer.css
+++ b/src/components/EmailCampaignComposer/EmailCampaignComposer.css
@@ -1,0 +1,324 @@
+.email-campaign-content {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-md);
+}
+
+.email-campaign-content .notification-box-wrapper { max-width: 57.5rem; }
+
+.email-campaign-content .notification-box-wrapper p {
+	font-size: var(--text-xs);
+	margin: var(--spacing-xs) 0 0;
+}
+
+.email-campaign-form {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-md);
+}
+
+.email-campaign-card {
+	border: var(--border);
+	border-color: color-mix(in srgb, var(--color-gray-500) 20%, transparent);
+	border-radius: var(--rounded-md);
+	box-sizing: border-box;
+	max-width: 57.5rem;
+	padding: var(--spacing-md);
+}
+
+.email-campaign-card h2 {
+	color: var(--color-gray-900);
+	font-size: var(--text-lg);
+	font-weight: var(--weight-regular);
+	line-height: 1.3;
+	margin: 0 0 var(--spacing-sm);
+}
+
+.email-campaign-help {
+	color: var(--color-gray-600);
+	font-size: var(--text-xs);
+	margin: calc(-1 * var(--spacing-xs)) 0 var(--spacing-sm);
+}
+
+.email-campaign-field { margin-top: var(--spacing-sm); }
+
+.email-campaign-filter-selects > label {
+	font-size: var(--text-xs);
+	font-weight: var(--weight-semibold);
+}
+
+.email-campaign-field textarea,
+.email-campaign-search input,
+.email-campaign-filter-selects select {
+	background-color: var(--color-input);
+	border: var(--border);
+	border-radius: var(--rounded-xs);
+	box-sizing: border-box;
+	color: var(--color-foreground);
+	font-family: inherit;
+	font-size: var(--text-xs);
+	padding: var(--spacing-xs);
+	width: 100%;
+}
+
+.email-campaign-field textarea {
+	line-height: 1.5;
+	resize: vertical;
+}
+
+.email-campaign-field textarea:focus,
+.email-campaign-search input:focus,
+.email-campaign-filter-selects select:focus {
+	border-color: var(--color-accent);
+	outline: var(--border-base) solid var(--color-accent);
+	outline-offset: var(--border-base);
+}
+
+.email-campaign-choice-group,
+.email-campaign-selection-grid fieldset,
+.email-campaign-filter-grid fieldset {
+	border: 0;
+	margin: 0;
+	padding: 0;
+}
+
+.email-campaign-choice-group {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--spacing-md);
+}
+
+.email-campaign-choice-group label,
+.email-campaign-filter-grid fieldset label,
+.email-campaign-confirmation {
+	align-items: center;
+	display: flex;
+	font-size: var(--text-xs);
+	gap: var(--spacing-xs);
+}
+
+.email-campaign-choice-group input,
+.email-campaign-option-list input,
+.email-campaign-filter-grid input,
+.email-campaign-confirmation input {
+	accent-color: var(--color-accent);
+	height: 1rem;
+	width: 1rem;
+}
+
+.email-campaign-selection-grid {
+	display: grid;
+	gap: var(--spacing-md);
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	margin-top: var(--spacing-md);
+}
+
+.email-campaign-selection-grid legend,
+.email-campaign-filter-grid legend {
+	font-size: var(--text-xs);
+	font-weight: var(--weight-semibold);
+	margin-bottom: var(--spacing-xs);
+}
+
+.email-campaign-option-list {
+	border: var(--border);
+	border-color: var(--color-gray-300);
+	border-radius: var(--rounded-sm);
+	max-height: 15rem;
+	overflow-y: auto;
+}
+
+.email-campaign-option-list label {
+	align-items: center;
+	border-bottom: var(--border);
+	border-color: var(--color-gray-200);
+	display: grid;
+	font-size: var(--text-xs);
+	gap: var(--spacing-xs);
+	grid-template-columns: auto 1fr auto;
+	padding: 0.625rem var(--spacing-xs);
+}
+
+.email-campaign-option-list label:last-child { border-bottom: 0; }
+
+.email-campaign-option-list small {
+	color: var(--color-gray-600);
+	font-size: var(--text-2xs);
+}
+
+.email-campaign-search {
+	display: block;
+	margin-bottom: var(--spacing-xs);
+}
+
+.email-campaign-filter-grid {
+	display: grid;
+	gap: var(--spacing-lg);
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.email-campaign-filter-grid fieldset {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-xs);
+}
+
+.email-campaign-filter-selects {
+	display: grid;
+	gap: var(--spacing-xs);
+	grid-template-columns: 1fr;
+}
+
+.email-campaign-filter-selects select { padding-block: 0.5rem; }
+
+.email-campaign-section-heading {
+	align-items: flex-start;
+	display: flex;
+	gap: var(--spacing-md);
+	justify-content: space-between;
+}
+
+.email-campaign-section-heading .button {
+	flex-shrink: 0;
+	width: auto;
+}
+
+.email-campaign-preview-result {
+	background: var(--color-gray-50);
+	border-radius: var(--rounded-sm);
+	font-size: var(--text-xs);
+	margin-bottom: var(--spacing-md);
+	padding: var(--spacing-sm);
+}
+
+.email-campaign-preview-result ul {
+	display: grid;
+	gap: 0.25rem;
+	list-style: none;
+	margin: var(--spacing-xs) 0;
+	padding: 0;
+}
+
+.email-campaign-preview-result li {
+	display: flex;
+	gap: var(--spacing-xs);
+	justify-content: space-between;
+}
+
+.email-campaign-preview-result li span,
+.email-campaign-preview-result p { color: var(--color-gray-600); }
+
+.email-campaign-confirmation {
+	border-top: var(--border);
+	border-color: var(--color-gray-300);
+	font-weight: var(--weight-semibold);
+	margin-top: var(--spacing-sm);
+	padding-top: var(--spacing-sm);
+}
+
+.email-campaign-preview > .button { margin-top: var(--spacing-sm); }
+
+.email-campaign-history > ul {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-xs);
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.email-campaign-history li {
+	align-items: center;
+	background: var(--color-gray-50);
+	border-radius: var(--rounded-sm);
+	display: flex;
+	gap: var(--spacing-sm);
+	justify-content: space-between;
+	padding: var(--spacing-sm);
+}
+
+.email-campaign-history li > div {
+	display: flex;
+	flex-direction: column;
+}
+
+.email-campaign-history li strong { font-size: var(--text-xs); }
+
+.email-campaign-history li span {
+	color: var(--color-gray-600);
+	font-size: var(--text-2xs);
+}
+
+.email-campaign-history .email-campaign-history-result {
+	background: var(--color-green-card);
+	border-radius: var(--rounded-sm);
+	color: var(--color-green-text);
+	font-size: var(--text-xs);
+	padding: 0.375rem 0.75rem;
+	white-space: nowrap;
+}
+
+.email-campaign-history .email-campaign-history-result[data-status='failed'],
+.email-campaign-history .email-campaign-history-result[data-status='partially-failed'] {
+	background: var(--color-red-card);
+	color: var(--color-red-text);
+}
+
+.email-campaign-empty-state {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	min-height: 10.25rem;
+	padding: var(--spacing-md) var(--spacing-sm);
+}
+
+.email-campaign-empty-state .container {
+	height: 5rem;
+	width: 5rem;
+}
+
+.email-campaign-empty-state .empty-icon {
+	height: 4rem;
+	width: 4rem;
+}
+
+.email-campaign-empty-state .empty-icon-ellipse {
+	height: 0.4375rem;
+	width: 5rem;
+}
+
+.email-campaign-empty-state p {
+	color: var(--color-gray-500);
+	font-size: var(--text-xs);
+	margin: 0.25rem 0 0;
+}
+
+.email-campaign-status {
+	color: var(--color-gray-600);
+	font-size: var(--text-sm);
+	padding-block: var(--spacing-lg);
+}
+
+@media screen and (max-width: 48rem) {
+	.email-campaign-selection-grid,
+	.email-campaign-filter-grid { grid-template-columns: 1fr; }
+
+	.email-campaign-option-list label { grid-template-columns: auto 1fr; }
+
+	.email-campaign-option-list small { grid-column: 2; }
+}
+
+@media screen and (max-width: 40rem) {
+	.email-campaign-card { padding: var(--spacing-sm); }
+
+	.email-campaign-section-heading,
+	.email-campaign-history li {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.email-campaign-section-heading .button { width: 100%; }
+
+	.email-campaign-preview-result li { flex-direction: column; }
+}

--- a/src/components/EmailCampaignComposer/EmailCampaignComposer.tsx
+++ b/src/components/EmailCampaignComposer/EmailCampaignComposer.tsx
@@ -1,0 +1,506 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { AccessLevel, ProfileStatus } from '../../types/index.ts';
+import Button from '../Button/Button.tsx';
+import EmptyIcon from '../EmptyIcon/EmptyIcon.tsx';
+import HelperMessageComponent from '../HelperMessageComponent/HelperMessageComponent.tsx';
+import NotificationBox from '../NotificationBox/NotificationBox.tsx';
+import TextInputComponent from '../TextInputComponent/TextInputComponent.tsx';
+import './EmailCampaignComposer.css';
+
+interface AudienceProfile {
+	id: string;
+	name: string;
+	email: string;
+	accessLevel: AccessLevel;
+	profileStatus: ProfileStatus;
+	isBasedOnGTA: boolean;
+	canJoinLocalEvents: boolean;
+	teamIds: string[];
+}
+
+interface AudienceTeam {
+	id: string;
+	name: string;
+	memberCount: number;
+}
+
+interface AudienceOptions {
+	profiles: AudienceProfile[];
+	teams: AudienceTeam[];
+}
+
+interface AudienceSelection {
+	mode: 'all' | 'selected';
+	teamIds: string[];
+	profileIds: string[];
+	accessLevels: AccessLevel[];
+	profileStatuses: ProfileStatus[];
+	isBasedOnGTA?: boolean;
+	canJoinLocalEvents?: boolean;
+}
+
+interface PreviewRecipient {
+	id: string;
+	name: string;
+	email: string;
+}
+
+interface CampaignSummary {
+	id: string;
+	subject: string;
+	status: 'failed' | 'partially-failed' | 'sending' | 'sent';
+	recipientCount: number;
+	sentCount: number;
+	failedCount: number;
+	insertedAt: string;
+	sentAt?: string | null;
+	createdByName: string;
+}
+
+type BooleanFilter = 'any' | 'no' | 'yes';
+
+const ACCESS_LEVELS: AccessLevel[] = ['volunteer', 'organizer', 'admin'];
+const PROFILE_STATUSES: ProfileStatus[] = ['activated', 'tos-accepted', 'social-handle-provided', 'profile-completed'];
+const PREVIEW_DISPLAY_LIMIT = 10;
+
+function toBooleanFilter(value: BooleanFilter): boolean | undefined {
+	if (value === 'any') { return undefined; }
+	return value === 'yes';
+}
+
+function toggleSelection<T>(values: T[], value: T): T[] {
+	return values.includes(value) ? values.filter((item) => item !== value) : [...values, value];
+}
+
+function formatLabel(value: string) {
+	return value.split('-').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
+}
+
+function getResponseMessage(data: unknown, fallback: string) {
+	if (typeof data === 'object' && data !== null && 'message' in data && typeof data.message === 'string') {
+		return data.message;
+	}
+	return fallback;
+}
+
+// State from the four form sections is coordinated here so every audience change invalidates the send confirmation.
+// eslint-disable-next-line complexity
+const EmailCampaignComposer = (): React.JSX.Element => {
+	const [options, setOptions] = useState<AudienceOptions | null>(null);
+	const [campaigns, setCampaigns] = useState<CampaignSummary[]>([]);
+	const [mode, setMode] = useState<'all' | 'selected'>('all');
+	const [teamIds, setTeamIds] = useState<string[]>([]);
+	const [profileIds, setProfileIds] = useState<string[]>([]);
+	const [accessLevels, setAccessLevels] = useState<AccessLevel[]>([]);
+	const [profileStatuses, setProfileStatuses] = useState<ProfileStatus[]>([]);
+	const [isBasedOnGTA, setIsBasedOnGTA] = useState<BooleanFilter>('any');
+	const [canJoinLocalEvents, setCanJoinLocalEvents] = useState<BooleanFilter>('any');
+	const [profileSearch, setProfileSearch] = useState('');
+	const [subject, setSubject] = useState('');
+	const [message, setMessage] = useState('');
+	const [previewRecipients, setPreviewRecipients] = useState<PreviewRecipient[] | null>(null);
+	const [confirmed, setConfirmed] = useState(false);
+	const [isLoading, setIsLoading] = useState(true);
+	const [isPreviewing, setIsPreviewing] = useState(false);
+	const [isSending, setIsSending] = useState(false);
+	const [feedback, setFeedback] = useState<{ title: string, message: string, variant: 'error' | 'success' } | null>(null);
+	const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
+
+	const loadData = useCallback(async (): Promise<void> => {
+		try {
+			const [optionsResponse, campaignsResponse] = await Promise.all([
+				fetch('/api/email-campaigns/audience-options', { credentials: 'include' }),
+				fetch('/api/email-campaigns', { credentials: 'include' })
+			]);
+
+			if (!optionsResponse.ok || !campaignsResponse.ok) {
+				throw new Error('Unable to load notification data.');
+			}
+
+			const [audienceOptions, campaignData] = await Promise.all([
+				optionsResponse.json() as Promise<AudienceOptions>,
+				campaignsResponse.json() as Promise<{ data: CampaignSummary[] }>
+			]);
+			setOptions(audienceOptions);
+			setCampaigns(campaignData.data);
+		} catch (error) {
+			console.error('Error loading notification data:', error);
+			setFeedback({
+				title: 'Unable to load notifications',
+				message: 'Please refresh the page and try again.',
+				variant: 'error'
+			});
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		void loadData();
+	}, [loadData]);
+
+	const audience = useMemo<AudienceSelection>(() => ({
+		mode,
+		teamIds: mode === 'selected' ? teamIds : [],
+		profileIds: mode === 'selected' ? profileIds : [],
+		accessLevels,
+		profileStatuses,
+		isBasedOnGTA: toBooleanFilter(isBasedOnGTA),
+		canJoinLocalEvents: toBooleanFilter(canJoinLocalEvents)
+	}), [accessLevels, canJoinLocalEvents, isBasedOnGTA, mode, profileIds, profileStatuses, teamIds]);
+
+	const clearPreview = (): void => {
+		setPreviewRecipients(null);
+		setConfirmed(false);
+		setFeedback(null);
+	};
+
+	const updateAudience = (update: () => void): void => {
+		update();
+		clearPreview();
+	};
+
+	const filteredProfiles = useMemo(() => {
+		const search = profileSearch.trim().toLocaleLowerCase();
+		if (!search) { return options?.profiles ?? []; }
+		return (options?.profiles ?? []).filter(({ email, name }) => `${name} ${email}`.toLocaleLowerCase().includes(search));
+	}, [options, profileSearch]);
+
+	const canPreview = mode === 'all' || teamIds.length > 0 || profileIds.length > 0;
+
+	const previewAudience = async (): Promise<void> => {
+		if (!canPreview) {
+			setFeedback({ title: 'Select recipients', message: 'Select at least one team or individual volunteer.', variant: 'error' });
+			return;
+		}
+
+		setIsPreviewing(true);
+		setFeedback(null);
+		setConfirmed(false);
+
+		try {
+			const response = await fetch('/api/email-campaigns/preview', {
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ audience })
+			});
+			const data = await response.json() as { count?: number, recipients?: PreviewRecipient[], message?: string };
+
+			if (!response.ok || !data.recipients) {
+				throw new Error(getResponseMessage(data, 'Unable to preview the selected audience.'));
+			}
+
+			setPreviewRecipients(data.recipients);
+		} catch (error) {
+			setPreviewRecipients(null);
+			setFeedback({
+				title: 'Audience preview failed',
+				message: error instanceof Error ? error.message : 'Please try again.',
+				variant: 'error'
+			});
+		} finally {
+			setIsPreviewing(false);
+		}
+	};
+
+	const sendCampaign = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+		event.preventDefault();
+
+		if (!previewRecipients || previewRecipients.length === 0 || !confirmed) {
+			setFeedback({ title: 'Confirm recipients', message: 'Preview the audience and confirm the recipient list before sending.', variant: 'error' });
+			return;
+		}
+
+		setIsSending(true);
+		setFeedback(null);
+
+		try {
+			const response = await fetch('/api/email-campaigns', {
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ subject, message, audience, idempotencyKey })
+			});
+			const data = await response.json() as CampaignSummary | { message?: string };
+
+			if (!response.ok || !('recipientCount' in data)) {
+				throw new Error(getResponseMessage(data, 'Unable to send this email campaign.'));
+			}
+
+			const result = data;
+			setCampaigns((current) => [result, ...current.filter(({ id }) => id !== result.id)]);
+			setFeedback({
+				title: result.failedCount === 0 ? 'Notification sent' : 'Notification partially sent',
+				message: `${result.sentCount} sent${result.failedCount > 0 ? ` and ${result.failedCount} failed` : ''}.`,
+				variant: result.failedCount === 0 ? 'success' : 'error'
+			});
+			setSubject('');
+			setMessage('');
+			setPreviewRecipients(null);
+			setConfirmed(false);
+			setIdempotencyKey(crypto.randomUUID());
+		} catch (error) {
+			setFeedback({
+				title: 'Notification not sent',
+				message: error instanceof Error ? error.message : 'Please try again.',
+				variant: 'error'
+			});
+		} finally {
+			setIsSending(false);
+		}
+	};
+
+	if (isLoading) {
+		return <div className='email-campaign-status' role='status' aria-live='polite'>Loading notification tools...</div>;
+	}
+
+	return (
+		<div className='email-campaign-content'>
+			{feedback && (
+				<NotificationBox title={feedback.title} variant={feedback.variant} onDismiss={() => setFeedback(null)}>
+					<p>{feedback.message}</p>
+				</NotificationBox>
+			)}
+
+			<form
+				className='email-campaign-form'
+				onSubmit={(event) => {
+					sendCampaign(event).catch((error: unknown) => console.error('Error sending notification:', error));
+				}}
+			>
+				<section className='email-campaign-card' aria-labelledby='message-heading'>
+					<h2 id='message-heading'>Message</h2>
+					{/* TextInputComponent is uncontrolled, so the key remounts it when a successful send clears the form. */}
+					<TextInputComponent
+						key={idempotencyKey}
+						id='campaign-subject'
+						label='Subject'
+						maxLength={200}
+						required
+						value={subject}
+						onChange={(event) => setSubject(event.target.value)}
+					/>
+					<div className='text-input-component-container email-campaign-field'>
+						<span className='input-label-container'>
+							<label htmlFor='campaign-message'>Email message</label>
+						</span>
+						<textarea
+							id='campaign-message'
+							maxLength={16_384}
+							required
+							rows={8}
+							value={message}
+							onChange={(event) => setMessage(event.target.value)}
+						/>
+						<HelperMessageComponent labelText='Plain text is used to keep community emails safe and accessible.' />
+					</div>
+				</section>
+
+				<section className='email-campaign-card' aria-labelledby='audience-heading'>
+					<h2 id='audience-heading'>Recipients</h2>
+					<p className='email-campaign-help'>Choose the starting audience. Filters below narrow this selection.</p>
+					<fieldset className='email-campaign-choice-group'>
+						<legend className='sr-only'>Audience type</legend>
+						<label>
+							<input
+								type='radio'
+								name='audience-mode'
+								checked={mode === 'all'}
+								onChange={() => updateAudience(() => setMode('all'))}
+							/>
+							All active community members ({options?.profiles.length ?? 0})
+						</label>
+						<label>
+							<input
+								type='radio'
+								name='audience-mode'
+								checked={mode === 'selected'}
+								onChange={() => updateAudience(() => setMode('selected'))}
+							/>
+							Selected teams and individuals
+						</label>
+					</fieldset>
+
+					{mode === 'selected' && (
+						<div className='email-campaign-selection-grid'>
+							<fieldset>
+								<legend>Teams</legend>
+								<div className='email-campaign-option-list'>
+									{options?.teams.map((team) => (
+										<label key={team.id}>
+											<input
+												type='checkbox'
+												checked={teamIds.includes(team.id)}
+												onChange={() => updateAudience(() => setTeamIds((current) => toggleSelection(current, team.id)))}
+											/>
+											<span>{team.name}</span>
+											<small>{team.memberCount} {team.memberCount === 1 ? 'member' : 'members'}</small>
+										</label>
+									))}
+								</div>
+							</fieldset>
+
+							<fieldset>
+								<legend>Individual volunteers</legend>
+								<label className='email-campaign-search'>
+									<span className='sr-only'>Search volunteers</span>
+									<input
+										type='search'
+										placeholder='Search by name or email'
+										value={profileSearch}
+										onChange={(event) => setProfileSearch(event.target.value)}
+									/>
+								</label>
+								<div className='email-campaign-option-list'>
+									{filteredProfiles.map((profile) => (
+										<label key={profile.id}>
+											<input
+												type='checkbox'
+												checked={profileIds.includes(profile.id)}
+												onChange={() => updateAudience(() => setProfileIds((current) => toggleSelection(current, profile.id)))}
+											/>
+											<span>{profile.name}</span>
+											<small>{profile.email}</small>
+										</label>
+									))}
+								</div>
+							</fieldset>
+						</div>
+					)}
+				</section>
+
+				<section className='email-campaign-card' aria-labelledby='filters-heading'>
+					<h2 id='filters-heading'>Optional filters</h2>
+					<p className='email-campaign-help'>Selections within a filter are combined; different filters narrow the audience.</p>
+					<div className='email-campaign-filter-grid'>
+						<fieldset>
+							<legend>Access level</legend>
+							{ACCESS_LEVELS.map((level) => (
+								<label key={level}>
+									<input
+										type='checkbox'
+										checked={accessLevels.includes(level)}
+										onChange={() => updateAudience(() => setAccessLevels((current) => toggleSelection(current, level)))}
+									/>
+									{formatLabel(level)}
+								</label>
+							))}
+						</fieldset>
+
+						<fieldset>
+							<legend>Profile status</legend>
+							{PROFILE_STATUSES.map((status) => (
+								<label key={status}>
+									<input
+										type='checkbox'
+										checked={profileStatuses.includes(status)}
+										onChange={() => updateAudience(() => setProfileStatuses((current) => toggleSelection(current, status)))}
+									/>
+									{formatLabel(status)}
+								</label>
+							))}
+						</fieldset>
+
+						<div className='email-campaign-filter-selects'>
+							<label htmlFor='campaign-gta'>Based in the GTA</label>
+							<select id='campaign-gta' value={isBasedOnGTA} onChange={(event) => updateAudience(() => setIsBasedOnGTA(event.target.value as BooleanFilter))}>
+								<option value='any'>Any</option>
+								<option value='yes'>Yes</option>
+								<option value='no'>No</option>
+							</select>
+							<label htmlFor='campaign-local'>Available for local events</label>
+							<select
+								id='campaign-local'
+								value={canJoinLocalEvents}
+								onChange={(event) => updateAudience(() => setCanJoinLocalEvents(event.target.value as BooleanFilter))}
+							>
+								<option value='any'>Any</option>
+								<option value='yes'>Yes</option>
+								<option value='no'>No</option>
+							</select>
+						</div>
+					</div>
+				</section>
+
+				<section className='email-campaign-card email-campaign-preview' aria-labelledby='preview-heading'>
+					<div className='email-campaign-section-heading'>
+						<div>
+							<h2 id='preview-heading'>Preview and send</h2>
+							<p className='email-campaign-help'>The recipient list is recalculated whenever the audience changes.</p>
+						</div>
+						<Button
+							type='button'
+							size='small'
+							hasOutline
+							onClick={async () => previewAudience().catch((error: unknown) => console.error('Error previewing audience:', error))}
+							disabled={isPreviewing || !canPreview}
+						>
+							{isPreviewing ? 'Loading preview...' : 'Preview audience'}
+						</Button>
+					</div>
+
+					{previewRecipients && (
+						<div className='email-campaign-preview-result' aria-live='polite'>
+							<strong>{previewRecipients.length} eligible recipient{previewRecipients.length === 1 ? '' : 's'}</strong>
+							{previewRecipients.length === 0 ?
+								<p>No active community members match these selections.</p> :
+								(
+									<>
+										<ul>
+											{previewRecipients.slice(0, PREVIEW_DISPLAY_LIMIT).map((recipient) => (
+												<li key={recipient.id}>
+													{recipient.name} <span>{recipient.email}</span>
+												</li>
+											))}
+										</ul>
+										{previewRecipients.length > PREVIEW_DISPLAY_LIMIT && <p>And {previewRecipients.length - PREVIEW_DISPLAY_LIMIT} more.</p>}
+										<label className='email-campaign-confirmation'>
+											<input type='checkbox' checked={confirmed} onChange={(event) => setConfirmed(event.target.checked)} />
+											I have reviewed the audience and confirm this email should be sent.
+										</label>
+									</>
+								)}
+						</div>
+					)}
+
+					<Button
+						type='submit'
+						isPrimary
+						disabled={isSending || !confirmed || !previewRecipients?.length || !subject.trim() || !message.trim()}
+					>
+						{isSending ? 'Sending notification...' : `Send notification${previewRecipients?.length ? ` to ${previewRecipients.length}` : ''}`}
+					</Button>
+				</section>
+			</form>
+
+			<section className='email-campaign-card email-campaign-history' aria-labelledby='history-heading'>
+				<h2 id='history-heading'>Recent email notifications</h2>
+				{campaigns.length === 0 ?
+					(
+						<div className='email-campaign-empty-state'>
+							<EmptyIcon />
+							<p>No email notifications have been sent yet.</p>
+						</div>
+					) :
+					(
+						<ul>
+							{campaigns.map((campaign) => (
+								<li key={campaign.id}>
+									<div>
+										<strong>{campaign.subject}</strong>
+										<span>Sent by {campaign.createdByName} on {new Date(campaign.insertedAt).toLocaleString('en-CA')}</span>
+									</div>
+									<span className='email-campaign-history-result' data-status={campaign.status}>
+										{campaign.sentCount}/{campaign.recipientCount} sent{campaign.failedCount > 0 ? ` · ${campaign.failedCount} failed` : ''}
+									</span>
+								</li>
+							))}
+						</ul>
+					)}
+			</section>
+		</div>
+	);
+};
+
+export default EmailCampaignComposer;

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -1,0 +1,31 @@
+import { useAuth } from '../../context/AuthContext.tsx';
+import AuthenticatedLayout from '../AuthenticatedLayout/AuthenticatedLayout.tsx';
+import EmailCampaignComposer from '../EmailCampaignComposer/EmailCampaignComposer.tsx';
+
+const Notifications = (): React.JSX.Element => {
+	const { accessLevel } = useAuth();
+	const canSendNotifications = accessLevel === 'admin' || accessLevel === 'organizer';
+
+	return (
+		<AuthenticatedLayout activePage='notifications' mainClassName='notifications-page'>
+			<nav className='notifications-breadcrumb' aria-label='Breadcrumb'>
+				<a href='/pages/home'>Community</a>
+				<span>Notifications</span>
+			</nav>
+			<header className='notifications-header'>
+				<h1>Notifications</h1>
+				<p>Send email updates to the TorontoJS community.</p>
+			</header>
+			{canSendNotifications ?
+				<EmailCampaignComposer /> :
+				(
+					<section className='notifications-unavailable'>
+						<h2>Email notifications</h2>
+						<p>Community email notifications can only be created by organizers and administrators.</p>
+					</section>
+				)}
+		</AuthenticatedLayout>
+	);
+};
+
+export default Notifications;

--- a/src/pages/notifications/notifications.tsx
+++ b/src/pages/notifications/notifications.tsx
@@ -2,8 +2,8 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import '../../index.css';
 import './style.css';
-import AuthenticatedLayout from '../../components/AuthenticatedLayout/AuthenticatedLayout.tsx';
 import { AuthGate } from '../../components/AuthGate/AuthGate.tsx';
+import Notifications from '../../components/Notifications/Notifications.tsx';
 import { AuthProvider } from '../../context/AuthContext.tsx';
 import { useHeartBeatProtected } from '../../hooks/useHeartBeat.ts';
 
@@ -14,10 +14,7 @@ createRoot(root).render(
 		<StrictMode>
 			<AuthProvider>
 				<AuthGate hook={useHeartBeatProtected}>
-					<AuthenticatedLayout mainClassName='notifications-page'>
-						<h1>Notifications</h1>
-						<p>Under construction</p>
-					</AuthenticatedLayout>
+					<Notifications />
 				</AuthGate>
 			</AuthProvider>
 		</StrictMode>

--- a/src/pages/notifications/style.css
+++ b/src/pages/notifications/style.css
@@ -1,30 +1,70 @@
 .notifications-page {
-	align-items: center;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	gap: var(--spacing-xs);
-	margin: 0.625rem 0.9375rem 2.5rem;
-	min-height: 32rem;
+	margin: 0.625rem 0.9375rem var(--spacing-lg);
+	max-width: 57.5rem;
 }
 
-.notifications-page h1 {
+.notifications-breadcrumb {
+	align-items: center;
+	color: var(--color-gray-600);
+	display: flex;
+	font-size: var(--text-xs);
+	gap: 0.5rem;
+	margin-bottom: 1.25rem;
+}
+
+.notifications-breadcrumb a {
 	color: var(--color-black);
-	font-size: var(--text-xl);
+	font-weight: var(--weight-semibold);
+	text-decoration: underline;
+}
+
+.notifications-breadcrumb a::after {
+	color: var(--color-gray-500);
+	content: '>';
+	display: inline-block;
+	margin-left: 0.5rem;
+	text-decoration: none;
+}
+
+.notifications-header { margin-bottom: var(--spacing-md); }
+
+.notifications-header h1 {
+	color: var(--color-black);
+	font-size: var(--text-4xl);
 	font-weight: var(--weight-bold);
 	line-height: 1.2;
+	margin: 0 0 var(--spacing-xs);
+}
+
+.notifications-header p {
+	color: var(--color-gray-600);
+	font-size: var(--text-sm);
 	margin: 0;
 }
 
-.notifications-page p {
+.notifications-unavailable {
+	border: var(--border);
+	border-color: color-mix(in srgb, var(--color-gray-500) 20%, transparent);
+	border-radius: var(--rounded-md);
+	padding: var(--spacing-md);
+}
+
+.notifications-unavailable h2 {
+	font-size: var(--text-lg);
+	font-weight: var(--weight-regular);
+	margin: 0 0 var(--spacing-xs);
+}
+
+.notifications-unavailable p {
 	color: var(--color-gray-600);
-	font-size: var(--text-base);
+	font-size: var(--text-xs);
 	margin: 0;
 }
 
 @media screen and (max-width: 40rem) {
-	.notifications-page {
-		margin: 0 1rem 2rem;
-		min-height: 24rem;
-	}
+	.notifications-breadcrumb { display: none; }
+
+	.notifications-page { margin: 0 1rem 2rem; }
+
+	.notifications-header h1 { font-size: var(--text-2xl); }
 }

--- a/tests/e2e/email-notifications.spec.ts
+++ b/tests/e2e/email-notifications.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test';
+
+const teamId = '22222222-2222-4222-8222-222222222222';
+const profileId = '11111111-1111-4111-8111-111111111111';
+
+const audienceOptions = {
+	profiles: [{
+		id: profileId,
+		name: 'Ada Lovelace',
+		email: 'ada@example.com',
+		accessLevel: 'volunteer',
+		profileStatus: 'profile-completed',
+		isBasedOnGTA: true,
+		canJoinLocalEvents: true,
+		teamIds: [teamId]
+	}],
+	teams: [{ id: teamId, name: 'Website Team', memberCount: 1 }]
+};
+
+test.beforeEach(async ({ page }) => {
+	await page.route('**/api/auth/heartbeat', async (route) =>
+		route.fulfill({
+			json: {
+				access: 'organizer',
+				status: 'profile-completed'
+			}
+		}));
+});
+
+test('organizers can select, preview, confirm, and send an email notification', async ({ page }) => {
+	let submittedCampaign: Record<string, unknown> | undefined;
+
+	await page.route('**/api/email-campaigns/audience-options', async (route) => route.fulfill({ json: audienceOptions }));
+	await page.route('**/api/email-campaigns/preview', async (route) =>
+		route.fulfill({
+			json: { count: 1, recipients: [{ id: profileId, name: 'Ada Lovelace', email: 'ada@example.com' }] }
+		}));
+	await page.route('**/api/email-campaigns', async (route) => {
+		if (route.request().method() === 'GET') {
+			await route.fulfill({ json: { data: [] } });
+			return;
+		}
+
+		submittedCampaign = route.request().postDataJSON() as Record<string, unknown>;
+		await route.fulfill({
+			status: 201,
+			json: {
+				id: crypto.randomUUID(),
+				subject: 'Volunteer update',
+				status: 'sent',
+				recipientCount: 1,
+				sentCount: 1,
+				failedCount: 0,
+				insertedAt: new Date().toISOString(),
+				sentAt: new Date().toISOString(),
+				createdByName: 'Organizer'
+			}
+		});
+	});
+
+	await page.goto('/pages/notifications/');
+	await expect(page.getByRole('heading', { name: 'Notifications', level: 1 })).toBeVisible();
+	await page.getByLabel('Subject').fill('Volunteer update');
+	await page.getByLabel('Email message').fill('Please review this community update.');
+	await page.getByLabel('Selected teams and individuals').check();
+	await page.getByLabel(/Website Team/u).check();
+	await page.getByLabel(/Ada Lovelace/u).check();
+	await page.getByLabel('Volunteer', { exact: true }).check();
+	await page.getByRole('button', { name: 'Preview audience' }).click();
+
+	await expect(page.getByText('1 eligible recipient')).toBeVisible();
+	await expect(page.getByLabel('Preview and send').getByText('ada@example.com')).toBeVisible();
+	await page.getByLabel(/I have reviewed the audience/u).check();
+	await page.getByRole('button', { name: 'Send notification to 1' }).click();
+
+	await expect(page.getByText('1 sent.')).toBeVisible();
+	expect(submittedCampaign).toMatchObject({
+		subject: 'Volunteer update',
+		message: 'Please review this community update.',
+		audience: {
+			mode: 'selected',
+			teamIds: [teamId],
+			profileIds: [profileId],
+			accessLevels: ['volunteer']
+		}
+	});
+});
+
+test('volunteers see the protected notifications page without campaign controls', async ({ page }) => {
+	await page.route('**/api/auth/heartbeat', async (route) =>
+		route.fulfill({
+			json: {
+				access: 'volunteer',
+				status: 'profile-completed'
+			}
+		}));
+
+	await page.goto('/pages/notifications/');
+
+	await expect(page.getByRole('heading', { name: 'Email notifications' })).toBeVisible();
+	await expect(page.getByText(/only be created by organizers and administrators/u)).toBeVisible();
+	await expect(page.getByRole('button', { name: /send notification/iu })).toHaveCount(0);
+});


### PR DESCRIPTION
Lets organizers and admins send plain-text email updates to filtered segments of the community from the notifications page.

- api: /api/email-campaigns routes for audience options, preview, list, and send
- db: migration 0008 adding email_campaign and email_campaign_recipient
- email: community-notification template sent through Resend
- ui: EmailCampaignComposer and the notifications page shell
- ui: header bell now carries the active state for the notifications page via the activePage prop instead of sniffing location.pathname


Claude-Session: https://claude.ai/code/session_01SnuiVrrktvfziFdppmtcah

## Summary

<!-- Describe what problem you are tying to solve -->

## Tests

<!-- Tell us if the changes have been tested and how -->

## Additional information

<!-- Do we need additional context or information about the changes? Please describe it here -->
